### PR TITLE
Basic source links

### DIFF
--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -17,6 +17,8 @@ structure SiteContext where
   root : String
   result : AnalyzerResult
   currentName : Option Name
+  -- Generates a URL pointing to the source of the given module Name
+  sourceLinker : Name → Option DeclarationRange → String
 
 def setCurrentName (name : Name) (ctx : SiteContext) := {ctx with currentName := some name}
 
@@ -26,6 +28,7 @@ abbrev HtmlM := HtmlT Id
 def getRoot : HtmlM String := do (←read).root
 def getResult : HtmlM AnalyzerResult := do (←read).result
 def getCurrentName : HtmlM (Option Name) := do (←read).currentName
+def getSourceUrl (module : Name) (range : Option DeclarationRange): HtmlM String := do (←read).sourceLinker module range
 
 def templateExtends {α β : Type} (base : α → HtmlM β) (new : HtmlM α) : HtmlM β :=
   new >>= base


### PR DESCRIPTION
The current implementation is only capable of linking declarations right from the package that is being documented, there
are two other cases possible that are not handled yet:
1. Declarations that are coming from `Init`, `Std` or `Lean` aka the compiler itself, this should be addressable by obtaining the
    compiler revision and linking to the compiler repository if the declaration is coming from one of those modules
2. Modules that are pulled in as dependencies through Lake, for this case it is probably possible to obtain the URLs and revisions based on the Lakefile and link to those instead.

This implementation only deals with the first as this can deal perfectly fine with mathlib since it has no dependencies apart from the compiler