### PR TITLE
fix: do not show top-level modules twice in navbar

### DIFF
--- a/DocGen4/Output/Inductive.lean
+++ b/DocGen4/Output/Inductive.lean
@@ -10,8 +10,8 @@ def ctorToHtml (i : NameInfo) : HtmlM Html := do
   let name := i.name.toString
   return <li «class»="constructor" id={name}>{shortName} : [←infoFormatToHtml i.type]</li>
 
-def inductiveToHtml (i : InductiveInfo) : HtmlM (Array Html) := do
-  #[Html.element "ul" false #[("class", "constructors")] (←i.ctors.toArray.mapM ctorToHtml)]
+def inductiveToHtml (i : InductiveInfo) : HtmlM (Array Html) :=
+  return #[<ul "class"="constructors">[← i.ctors.toArray.mapM ctorToHtml]</ul>]
 
 end Output
 end DocGen4

--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -32,13 +32,12 @@ partial def moduleListDir (h : Hierarchy) : HtmlM Html := do
     [fileNodes]
   </details>
 
-def moduleList : HtmlM (Array Html) := do
+def moduleList : HtmlM Html := do
   let hierarchy := (←getResult).hierarchy
   let mut list := Array.empty
   for (n, cs) in hierarchy.getChildren do
-    list := list.push <h4>{n.toString}</h4>
     list := list.push $ ←moduleListDir cs
-  list
+  return <div "class"="module_list">[list]</div>
 
 def navbar : HtmlM Html := do
   <nav «class»="nav">
@@ -54,7 +53,7 @@ def navbar : HtmlM Html := do
     <div «class»="nav_link"><a href={s!"{←getRoot}references.html"}>references</a></div>
     -/
     <h3>Library</h3>
-    [←moduleList]
+    {← moduleList}
   </nav>
 
 end Output

--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -13,16 +13,10 @@ namespace Output
 open Lean
 open scoped DocGen4.Jsx
 
-def moduleListFile (file : Name) : HtmlM Html := do
-  let attributes := match ←getCurrentName with
-  | some name =>
-    if file == name then
-      #[("class", "nav_link"), ("visible", "")]
-    else
-      #[("class", "nav_link")]
-  | none => #[("class", "nav_link")]
-  let nodes := #[<a href={s!"{←moduleNameToLink file}"}>{file.toString}</a>]
-  return Html.element "div" false attributes nodes
+def moduleListFile (file : Name) : HtmlM Html :=
+  return <div "class"="nav_link" [if (← getCurrentName) == file then #[("visible", "")] else #[]]>
+    <a href={← moduleNameToLink file}>{file.toString}</a>
+  </div>
 
 partial def moduleListDir (h : Hierarchy) : HtmlM Html := do
   let children := Array.mk (h.getChildren.toList.map Prod.snd)
@@ -31,16 +25,12 @@ partial def moduleListDir (h : Hierarchy) : HtmlM Html := do
   let dirNodes ← (dirs.mapM moduleListDir)
   let fileNodes ← (files.mapM moduleListFile)
   let moduleLink ← moduleNameToLink h.getName
-  let attributes := match ←getCurrentName with
-  | some name =>
-    if h.getName.isPrefixOf name then
-      #[("class", "nav_sect"), ("data-path", moduleLink), ("open", "")]
-    else
-      #[("class", "nav_sect"), ("data-path", moduleLink)]
-  | none =>
-      #[("class", "nav_sect"), ("data-path", moduleLink)]
-  let nodes := #[<summary>{h.getName.toString}</summary>] ++ dirNodes ++ fileNodes
-  return Html.element "details" false attributes nodes
+  return <details "class"="nav_sect" "data-path"={moduleLink}
+      [if (← getCurrentName).any (h.getName.isPrefixOf ·) then #[("open", "")] else #[]]>
+    <summary>{h.getName.toString}</summary>
+    [dirNodes]
+    [fileNodes]
+  </details>
 
 def moduleList : HtmlM (Array Html) := do
   let hierarchy := (←getResult).hierarchy

--- a/DocGen4/ToHtmlFormat.lean
+++ b/DocGen4/ToHtmlFormat.lean
@@ -93,7 +93,7 @@ def translateAttrs (attrs : Array Syntax) : MacroM Syntax := do
         | `(jsxAttrVal| {$v}) => v
         | `(jsxAttrVal| $v:strLit) => v
         | _ => Macro.throwUnsupported
-      `(($as).push ($n, $v))
+      `(($as).push ($n, ($v : String)))
     | `(jsxAttr| [$t]) => `($as ++ ($t : Array (String × String)))
     | _ => Macro.throwUnsupported
   return as

--- a/Main.lean
+++ b/Main.lean
@@ -4,6 +4,10 @@ import Lean
 open DocGen4 Lean IO
 
 def main (args : List String) : IO Unit := do
+  if args.isEmpty then
+    IO.println "Usage: doc-gen4 root/url/ Module1 Module2 ..."
+    IO.Process.exit 1
+    return
   let root := args.head!
   let modules := args.tail!
   let path ← lakeSetupSearchPath (←getLakePath) modules.toArray

--- a/static/style.css
+++ b/static/style.css
@@ -268,6 +268,11 @@ nav {
     margin-bottom: 1ex;
 }
 
+/* top-level modules in left navbar */
+.nav .module_list > details {
+    margin-top: 1ex;
+}
+
 .nav details > * {
     padding-left: 2ex;
 }
@@ -285,10 +290,6 @@ nav {
 
 .nav h3 {
     margin-block-end: 4px;
-}
-
-.nav h4 {
-    margin-bottom: 1ex;
 }
 
 /* People use way too long declaration names. */


### PR DESCRIPTION
When browsing mathlib4_docs, the first thing that jumps into the eye is the duplicate module names on the left side.  This PR removes the header, which is one of the duplicates.

![docgen4navbarheader](https://user-images.githubusercontent.com/313929/150354600-1291b472-d0f1-4c7d-a3e3-5082042fc9c6.png)

I've also taken the liberty of extending the `<div>[children]</div>` syntax to attributes (i.e., `<div [attributes] />`) since that simplifies the navbar code quite a bit.