### PR TITLE
Make paths generated by doc-gen4 relative.

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -62,10 +62,9 @@ def sourceLinker : IO (Name → Option DeclarationRange → String) := do
     | none => basic
 
 def htmlOutput (result : AnalyzerResult) : IO Unit := do
-  let config := { currentDepth := 0, result := result, currentName := none, sourceLinker := ←sourceLinker}
   let basePath := FilePath.mk "./build/doc/"
-  let indexHtml := ReaderT.run index config 
-  let notFoundHtml := ReaderT.run notFound config
+  let config := { basePath := basePath, currentPath := basePath, result := result, currentName := none, sourceLinker := ←sourceLinker}
+
   FS.createDirAll basePath
   FS.createDirAll (basePath / "find")
 
@@ -74,14 +73,16 @@ def htmlOutput (result : AnalyzerResult) : IO Unit := do
     for decl in mod.members do
       let findDir := basePath / "find" / decl.getName.toString
       let findFile := (findDir / "index.html")
-      let config := { config with currentDepth := findFile.components.length - basePath.components.length }
+      let config := { config with currentPath := findDir }
       let findHtml := ReaderT.run (findRedirectHtml decl.getName) config
       FS.createDirAll findDir
-      FS.writeFile  findFile findHtml.toString
+      FS.writeFile findFile findHtml.toString
       let obj := Json.mkObj [("name", decl.getName.toString), ("description", decl.getDocString.getD "")]
       declList := declList.push obj
   let json := Json.arr declList
 
+  let indexHtml := ReaderT.run index config 
+  let notFoundHtml := ReaderT.run notFound config
   FS.writeFile (basePath / "searchable_data.bmp") json.compress
   FS.writeFile (basePath / "index.html") indexHtml.toString
   FS.writeFile (basePath / "style.css") styleCss
@@ -89,11 +90,12 @@ def htmlOutput (result : AnalyzerResult) : IO Unit := do
   FS.writeFile (basePath / "nav.js") navJs
   FS.writeFile (basePath / "search.js") searchJs
   for (module, content) in result.moduleInfo.toArray do
-    let path := moduleNameToFile basePath module
-    let config := { config with currentDepth := path.components.length - basePath.components.length - 1 }
+    let fileDir := moduleNameToDirectory basePath module
+    let filePath := moduleNameToFile basePath module
+    let config := { config with currentPath := fileDir }
     let moduleHtml := ReaderT.run (moduleToHtml content) config
-    FS.createDirAll $ moduleNameToDirectory basePath module
-    FS.writeFile path moduleHtml.toString
+    FS.createDirAll $ fileDir
+    FS.writeFile filePath moduleHtml.toString
 
 end DocGen4
 

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -14,9 +14,9 @@ open scoped DocGen4.Jsx
 open Lean System Widget Elab
 
 structure SiteContext where
-  -- root : String
   result : AnalyzerResult
   currentName : Option Name
+  -- Current nesting depth of folder. Used to generate relative paths.
   currentDepth : Nat
   -- Generates a URL pointing to the source of the given module Name
   sourceLinker : Name → Option DeclarationRange → String
@@ -34,7 +34,6 @@ def getRoot : HtmlM String := do
   let d <- getCurrentDepth
   return (go d)
 
--- def getRoot : HtmlM String := do pure (←read).root
 def getResult : HtmlM AnalyzerResult := do pure (←read).result
 def getCurrentName : HtmlM (Option Name) := do pure (←read).currentName
 def getSourceUrl (module : Name) (range : Option DeclarationRange): HtmlM String := do pure $ (←read).sourceLinker module range

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -30,6 +30,7 @@ def getCurrentDepth : HtmlM Nat := do pure (<-read).currentDepth
 def getRoot : HtmlM String := do
   let rec go: Nat -> String
   | 0 => ""
+  | 1 => ""
   | Nat.succ n' => "../" ++ go n'
   let d <- getCurrentDepth
   return (go d)
@@ -43,7 +44,7 @@ def templateExtends {α β : Type} (base : α → HtmlM β) (new : HtmlM α) : H
 
 def moduleNameToLink (n : Name) : HtmlM String := do
   let parts := n.components.map Name.toString
-  pure $ (←getRoot) ++ (parts.intersperse "/").foldl (· ++ ·) "" ++ ".html"
+  pure $ (<- getRoot) ++ (parts.intersperse "/").foldl (· ++ ·) "" ++ ".html"
 
 def moduleNameToFile (basePath : FilePath) (n : Name) : FilePath :=
   let parts := n.components.map Name.toString

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -70,7 +70,6 @@ def moduleNameToLink (n : Name) : HtmlM String := do
 
 def moduleNameToFile (basePath : FilePath) (n : Name) : FilePath :=
   let parts := n.components.map Name.toString
-  -- FilePath.withExtension (basePath / parts.foldl (· / ·) (FilePath.mk ".")) "html"
   FilePath.withExtension (basePath / parts.foldl (· / ·) (FilePath.mk ".")) "html"
 
 

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -14,9 +14,10 @@ open scoped DocGen4.Jsx
 open Lean System Widget Elab
 
 structure SiteContext where
-  root : String
+  -- root : String
   result : AnalyzerResult
   currentName : Option Name
+  currentDepth : Nat
   -- Generates a URL pointing to the source of the given module Name
   sourceLinker : Name → Option DeclarationRange → String
 
@@ -25,7 +26,15 @@ def setCurrentName (name : Name) (ctx : SiteContext) := {ctx with currentName :=
 abbrev HtmlT := ReaderT SiteContext
 abbrev HtmlM := HtmlT Id
 
-def getRoot : HtmlM String := do pure (←read).root
+def getCurrentDepth : HtmlM Nat := do pure (<-read).currentDepth
+def getRoot : HtmlM String := do
+  let rec go: Nat -> String
+  | 0 => ""
+  | Nat.succ n' => "../" ++ go n'
+  let d <- getCurrentDepth
+  return (go d)
+
+-- def getRoot : HtmlM String := do pure (←read).root
 def getResult : HtmlM AnalyzerResult := do pure (←read).result
 def getCurrentName : HtmlM (Option Name) := do pure (←read).currentName
 def getSourceUrl (module : Name) (range : Option DeclarationRange): HtmlM String := do pure $ (←read).sourceLinker module range

--- a/Main.lean
+++ b/Main.lean
@@ -5,13 +5,12 @@ open DocGen4 Lean IO
 
 def main (args : List String) : IO Unit := do
   if args.isEmpty then
-    IO.println "Usage: doc-gen4 root/url/ Module1 Module2 ..."
+    IO.println "Usage: doc-gen4 Module1 Module2 ..."
     IO.Process.exit 1
     return
-  let root := args.head!
   let modules := args.tail!
   let path ← lakeSetupSearchPath (←getLakePath) modules.toArray
   IO.println s!"Loading modules from: {path}"
   let doc ← load $ modules.map Name.mkSimple
   IO.println "Outputting HTML"
-  htmlOutput doc root
+  htmlOutput doc

--- a/Main.lean
+++ b/Main.lean
@@ -3,12 +3,11 @@ import Lean
 
 open DocGen4 Lean IO
 
-def main (args : List String) : IO Unit := do
-  if args.isEmpty then
+def main (modules : List String) : IO Unit := do
+  if modules.isEmpty then
     IO.println "Usage: doc-gen4 Module1 Module2 ..."
     IO.Process.exit 1
     return
-  let modules := args.tail!
   let path ← lakeSetupSearchPath (←getLakePath) modules.toArray
   IO.println s!"Loading modules from: {path}"
   let doc ← load $ modules.map Name.mkSimple


### PR DESCRIPTION
This obviates the need for a root URL, and follows other tools such as the Rust documentation generator, which always generate relative paths.

Eg: `view-source:https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/dep_graph/struct.WorkProduct.html#structfield.cgu_name`