### PR TITLE
fix: add nav link to non leaf node modules

### DIFF
--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -28,7 +28,7 @@ partial def moduleListDir (h : Hierarchy) : HtmlM Html := do
   pure
     <details "class"="nav_sect" "data-path"={moduleLink}
       [if (←getCurrentName).any (h.getName.isPrefixOf ·) then #[("open", "")] else #[]]>
-      <summary>{h.getName.toString}</summary>
+      <summary><a "href"={← moduleNameToLink h.getName}>{h.getName.toString}</a></summary>
       [dirNodes]
       [fileNodes]
     </details>

--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -29,7 +29,7 @@ partial def moduleListDir (h : Hierarchy) : HtmlM Html := do
   pure
     <details "class"="nav_sect" "data-path"={moduleLink}
       [if (←getCurrentName).any (h.getName.isPrefixOf ·) then #[("open", "")] else #[]]>
-      <summary><a "href"={← moduleNameToLink h.getName}>{h.getName.toString}</a></summary>
+      {Html.element "summary" true #[] #[<a "href"={← moduleNameToLink h.getName}>{h.getName.toString}</a>]}
       [dirNodes]
       [fileNodes]
     </details>

--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -21,7 +21,8 @@ def moduleListFile (file : Name) : HtmlM Html := do
 partial def moduleListDir (h : Hierarchy) : HtmlM Html := do
   let children := Array.mk (h.getChildren.toList.map Prod.snd)
   let dirs := children.filter (λ c => c.getChildren.toList.length != 0)
-  let files := children.filter Hierarchy.isFile |>.map Hierarchy.getName
+  let files := children.filter (λ c => Hierarchy.isFile c ∧ c.getChildren.toList.length = 0)
+    |>.map Hierarchy.getName
   let dirNodes ← (dirs.mapM moduleListDir)
   let fileNodes ← (files.mapM moduleListFile)
   let moduleLink ← moduleNameToLink h.getName

--- a/DocGen4/ToHtmlFormat.lean
+++ b/DocGen4/ToHtmlFormat.lean
@@ -33,9 +33,9 @@ def attributesToString (attrs : Array (String × String)) :String :=
 
 -- TODO: Termination proof
 partial def toStringAux : Html → String
-| element tag false attrs #[text s] => s!"<{tag}{attributesToString attrs}>{s}</{tag}>"
-| element tag false attrs #[child] => s!"<{tag}{attributesToString attrs}>{child.toStringAux}</{tag}>"
-| element tag false attrs children => s!"<{tag}{attributesToString attrs}>{children.foldl (· ++ toStringAux ·) ""}</{tag}>"
+| element tag false attrs #[text s] => s!"<{tag}{attributesToString attrs}>{s}</{tag}>\n"
+| element tag false attrs #[child] => s!"<{tag}{attributesToString attrs}>\n{child.toStringAux}</{tag}>\n"
+| element tag false attrs children => s!"<{tag}{attributesToString attrs}>\n{children.foldl (· ++ toStringAux ·) ""}</{tag}>\n"
 | element tag true attrs children => s!"<{tag}{attributesToString attrs}>{children.foldl (· ++ toStringAux ·) ""}</{tag}>"
 | text s => s
 

--- a/DocGen4/ToHtmlFormat.lean
+++ b/DocGen4/ToHtmlFormat.lean
@@ -33,9 +33,9 @@ def attributesToString (attrs : Array (String × String)) :String :=
 
 -- TODO: Termination proof
 partial def toStringAux : Html → String
-| element tag false attrs #[text s] => s!"<{tag}{attributesToString attrs}>{s}</{tag}>\n"
-| element tag false attrs #[child] => s!"<{tag}{attributesToString attrs}>\n{child.toStringAux}</{tag}>\n"
-| element tag false attrs children => s!"<{tag}{attributesToString attrs}>\n{children.foldl (· ++ toStringAux ·) ""}</{tag}>\n"
+| element tag false attrs #[text s] => s!"<{tag}{attributesToString attrs}>{s}</{tag}>"
+| element tag false attrs #[child] => s!"<{tag}{attributesToString attrs}>{child.toStringAux}</{tag}>"
+| element tag false attrs children => s!"<{tag}{attributesToString attrs}>{children.foldl (· ++ toStringAux ·) ""}</{tag}>"
 | element tag true attrs children => s!"<{tag}{attributesToString attrs}>{children.foldl (· ++ toStringAux ·) ""}</{tag}>"
 | text s => s
 

--- a/static/style.css
+++ b/static/style.css
@@ -273,13 +273,10 @@ nav {
     margin-top: 1ex;
 }
 
-.nav details > * {
+.nav details, .nav_link {
     padding-left: 2ex;
 }
-.nav summary {
-    cursor: pointer;
-    padding-left: 0;
-}
+
 .nav summary::marker {
     font-size: 85%;
 }


### PR DESCRIPTION
Currently non leaf modules are ignored in sidebar navigation.
This PR fixes this problem, like this:

<img width="361" alt="截屏2022-02-18 下午2 06 33" src="https://user-images.githubusercontent.com/20809612/154627456-bedba6c6-006d-419a-8a5d-160d41ca429a.png">
