### PR TITLE
Add support for relative paths

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -93,24 +93,14 @@ def htmlOutput (result : AnalyzerResult) (ws : Lake.Workspace) (leanHash: String
   let mut declList := #[]
   for (module, mod) in result.moduleInfo.toArray do
     for decl in filterMapDocInfo mod.members do
--- <<<<<<< HEAD
       let name := decl.getName.toString
-      -- let findDir := basePath / "find" / ma,e
-      -- let findFile := (findDir / "index.html")
       let config := { config with depthToRoot := 2 }
-      -- let findHtml := ReaderT.run (findRedirectHtml decl.getName) config
-      -- FS.createDirAll findDir
-      -- FS.writeFile findFile findHtml.toString
-      -- let obj := Json.mkObj [("name", decl.getName.toString), ("description", decl.getDocString.getD "")]
--- =======
       let doc := decl.getDocString.getD ""
-      -- let root := module.getRoot 
       let root := Id.run <| ReaderT.run (getRoot) config
       let link :=  root ++ s!"../semantic/{decl.getName.hash}.xml#"
       let docLink := Id.run <| ReaderT.run (declNameToLink decl.getName) config
       let sourceLink := Id.run <| ReaderT.run (getSourceUrl mod.name decl.getDeclarationRange) config
       let obj := Json.mkObj [("name", name), ("doc", doc), ("link", link), ("docLink", docLink), ("sourceLink", sourceLink)]
--- >>>>>>> upstream/main
       declList := declList.push obj
       let xml := toString <| Id.run <| ReaderT.run (semanticXml decl) config 
       FS.writeFile (basePath / "semantic" / s!"{decl.getName.hash}.xml") xml

--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -91,7 +91,7 @@ def htmlOutput (result : AnalyzerResult) (ws : Lake.Workspace) (leanHash: String
   FS.createDirAll (basePath / "semantic")
 
   let mut declList := #[]
-  for (module, mod) in result.moduleInfo.toArray do
+  for (_, mod) in result.moduleInfo.toArray do
     for decl in filterMapDocInfo mod.members do
       let name := decl.getName.toString
       let config := { config with depthToRoot := 2 }

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -40,13 +40,11 @@ def templateExtends {α β : Type} (base : α → HtmlM β) (new : HtmlM α) : H
 
 def moduleNameToLink (n : Name) : HtmlM String := do
   let parts := n.components.map Name.toString
-  pure $ (<- getRoot) ++ (parts.intersperse "/").foldl (. ++ ·) "" ++ ".html"
+  pure $ (← getRoot) ++ (parts.intersperse "/").foldl (· ++ ·) "" ++ ".html"
 
 def moduleNameToFile (basePath : FilePath) (n : Name) : FilePath :=
   let parts := n.components.map Name.toString
   FilePath.withExtension (basePath / parts.foldl (· / ·) (FilePath.mk ".")) "html"
-
-
 
 def moduleNameToDirectory (basePath : FilePath) (n : Name) : FilePath :=
   let parts := n.components.dropLast.map Name.toString

--- a/Main.lean
+++ b/Main.lean
@@ -3,15 +3,13 @@ import Lean
 
 open DocGen4 Lean IO
 
-def main (args : List String) : IO Unit := do
-  if args.isEmpty then
-    IO.println "Usage: doc-gen4 root/url/ Module1 Module2 ..."
+def main (modules : List String) : IO Unit := do
+  if modules.isEmpty then
+    IO.println "Usage: doc-gen4 Module1 Module2 ..."
     IO.Process.exit 1
     return
-  let root := args.head!
-  let modules := args.tail!
   let path ← lakeSetupSearchPath (←getLakePath) modules.toArray
   IO.println s!"Loading modules from: {path}"
   let doc ← load $ modules.map Name.mkSimple
   IO.println "Outputting HTML"
-  htmlOutput doc root
+  htmlOutput doc

--- a/Main.lean
+++ b/Main.lean
@@ -5,7 +5,6 @@ import Cli
 open DocGen4 Lean Cli
 
 def runDocGenCmd (p : Parsed) : IO UInt32 := do
-  -- let root := p.positionalArg! "root" |>.as! String
   let modules : List String := p.variableArgsAs! String |>.toList
   let res ← lakeSetup modules
   match res with
@@ -22,7 +21,6 @@ def docGenCmd : Cmd := `[Cli|
   "A documentation generator for Lean 4."
 
   ARGS:
-    -- root : String; "The root URL to generate the HTML for (will be relative in the future)"
     ...modules : String; "The modules to generate the HTML for"
 ]
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Document Generator for Lean 4
 ## Usage
 You can call `doc-gen4` from the top of a Lake project like this:
 ```sh
-$ /path/to/doc-gen4 / Module
+$ /path/to/doc-gen4 Module
 ```
-Where the `/` is the root URL the HTML will refer to and `Module` is one or
-more of the top level modules you want to document.
+
+where `Module` is one or more of the top level modules you want to document.
 The tool will then proceed to compile the project using lake (if that hasn't happened yet),
 analyze it and put the result in `./build/doc`.
 You could e.g. host the files locally with the built-in Python webserver:

--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -23,7 +23,7 @@ fi
 
 # generate the docs
 cd $1
-../$2/build/bin/doc-gen4 /mathlib4_docs/ Mathlib
+../$2/build/bin/doc-gen4 Mathlib
 
 if [ "$3" = "true" ]; then
   cd ..


### PR DESCRIPTION
Based on a discussion with @hargoniX , we decided it is simpler to manually calculate the offset to the root when generating relative paths. This supersedes #32 , which calculates nesting depth by normalizing paths via `unsafePerformIO`+`realpath`. 

