### PR TITLE
feat: only linkify lean code

### DIFF
--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -190,7 +190,7 @@ partial def modifyElement (element : Element) : HtmlM Element :=
     -- auto link for inline <code></code>
     else if name = "code" ∧
       -- don't linkify code blocks explicitly tagged with a language other than lean
-      ((¬ attrs.contains "class") ∨ (((attrs.find? "class").getD "").splitOn).filter (fun s => s.startsWith "language-" ∧ s ≠ "language-lean") = []) then
+      (((attrs.find? "class").getD "").splitOn.all (fun s => s == "language-lean" || !s.startsWith "language-")) then
       autoLink el
     -- recursively modify
     else

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -188,7 +188,9 @@ partial def modifyElement (element : Element) : HtmlM Element :=
     else if name = "a" then
       extendAnchor el
     -- auto link for inline <code></code>
-    else if name = "code" ∧ attrs.find? "class" = "language-lean" then
+    else if name = "code" ∧
+      -- don't linkify code blocks explicitly tagged with a language other than lean
+      ((¬ attrs.contains "class") ∨ (((attrs.find? "class").getD "").splitOn).filter (fun s => s.startsWith "language-" ∧ s ≠ "language-lean") = []) then
       autoLink el
     -- recursively modify
     else

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -22,7 +22,7 @@ namespace Output
       splitAroundAux s p b (s.next i) r
 
 /--
-  Similar to `Stirng.split` in Lean core, but keeps the separater.
+  Similar to `String.split` in Lean core, but keeps the separater.
   e.g. `splitAround "a,b,c" (λ c => c = ',') = ["a", ",", "b", ",", "c"]`
 -/
 def splitAround (s : String) (p : Char → Bool) : List String := splitAroundAux s p 0 0 []
@@ -188,7 +188,7 @@ partial def modifyElement (element : Element) : HtmlM Element :=
     else if name = "a" then
       extendAnchor el
     -- auto link for inline <code></code>
-    else if name = "code" then
+    else if name = "code" ∧ attrs.contains "language-lean" then
       autoLink el
     -- recursively modify
     else

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -188,7 +188,7 @@ partial def modifyElement (element : Element) : HtmlM Element :=
     else if name = "a" then
       extendAnchor el
     -- auto link for inline <code></code>
-    else if name = "code" ∧ attrs.contains "language-lean" then
+    else if name = "code" ∧ attrs.find? "class" = "language-lean" then
       autoLink el
     -- recursively modify
     else


### PR DESCRIPTION
When linkifying code blocks in markdown comments we check that the language of the code block isn't explicitly set to something other than Lean.

E.g.
````
```julia
add(1, 1)
```
````
should not link to the lean definition of `add` in the docs.

We do this by checking that any `class` attribute of the form `language-...` on the code block is `language-lean` (or that there are none, so the default remains that code blocks are lean code)