### PR TITLE
Remove Unicode dependency to avoid large downloads for mathlib4 users

### DIFF
--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -54,7 +54,7 @@ partial def xmlGetHeadingId (el : Xml.Element) : String :=
       |>.filter (!·.isEmpty)
       |> replacement.intercalate
     unicodeToDrop (c : Char) : Bool :=
-      dalse -- TODO: restore the behavior described in the docstring
+      false -- TODO: restore the behavior described in the docstring
 
 /--
   This function try to find the given name, both globally and in current module.

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -1,7 +1,6 @@
 import CMark
 import DocGen4.Output.Template
 import Lean.Data.Parsec
-import Unicode.General.GeneralCategory
 
 open Lean Unicode  Xml Parser Parsec DocGen4.Process
 
@@ -55,9 +54,7 @@ partial def xmlGetHeadingId (el : Xml.Element) : String :=
       |>.filter (!·.isEmpty)
       |> replacement.intercalate
     unicodeToDrop (c : Char) : Bool :=
-      charInGeneralCategory c GeneralCategory.punctuation ||
-      charInGeneralCategory c GeneralCategory.separator ||
-      charInGeneralCategory c GeneralCategory.other
+      dalse -- TODO: restore the behavior described in the docstring
 
 /--
   This function try to find the given name, both globally and in current module.

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -2,7 +2,7 @@ import CMark
 import DocGen4.Output.Template
 import Lean.Data.Parsec
 
-open Lean Unicode  Xml Parser Parsec DocGen4.Process
+open Lean Xml Parser Parsec DocGen4.Process
 
 namespace DocGen4
 namespace Output

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -24,10 +24,4 @@
     "subDir?": null,
     "rev": "2447df5cc6e48eb965c3c3fba87e46d353b5e9f1",
     "name": "leanInk",
-    "inputRev?": "doc-gen"}},
-  {"git":
-   {"url": "https://github.com/xubaiw/Unicode.lean",
-    "subDir?": null,
-    "rev": "6dd6ae3a3839c8350a91876b090eda85cf538d1d",
-    "name": "Unicode",
-    "inputRev?": "main"}}]}
+    "inputRev?": "doc-gen"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -14,9 +14,6 @@ lean_exe «doc-gen4» {
 require CMark from git
   "https://github.com/xubaiw/CMark.lean" @ "main"
 
-require Unicode from git
-  "https://github.com/xubaiw/Unicode.lean" @ "main"
-
 require Cli from git
   "https://github.com/mhuisi/lean4-cli" @ "nightly"
 


### PR DESCRIPTION
Until `lake` learns to not download this, I would claim that the benefit of marginally-nicer URLs is not worth the cost of having every mathlib4 user download a large archive of unicode data.