### PR TITLE
fix implicit arg wrapping

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -335,6 +335,12 @@ nav {
     overflow-wrap: break-word;
 }
 
+/* Add a linebreak after a declaration name. */
+.decl_name::after {
+    content: "\A";
+    white-space: pre;
+}
+
 .nav_link {
     overflow-wrap: break-word;
 }
@@ -474,7 +480,7 @@ main h2, main h3, main h4, main h5, main h6 {
 
 .implicits, .impl_arg {
     color: black;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .decl_kind, .decl_name, .decl_extends {


### PR DESCRIPTION
ref #105
I just allowed wrapping and added a line break after `decl_name`.

<img src="https://user-images.githubusercontent.com/255417/222892356-4cc02703-7854-4fe8-bdd3-f22c4c3e242f.png" width="700">

It looks nice on narrow screens too:

<img src="https://user-images.githubusercontent.com/255417/222892390-3d8b4ad2-4b7e-4770-9556-733b8b3a1772.png" width="350">
