### PR TITLE
feat: list instances for defs also

### DIFF
--- a/DocGen4/Output/Module.lean
+++ b/DocGen4/Output/Module.lean
@@ -98,7 +98,7 @@ def docInfoToHtml (module : Name) (doc : DocInfo) : HtmlM Html := do
   -- extra information like equations and instances
   let extraInfoHtml ← match doc with
   | DocInfo.classInfo i => pure #[← classInstancesToHtml i.name]
-  | DocInfo.definitionInfo i => equationsToHtml i
+  | DocInfo.definitionInfo i => pure ((← equationsToHtml i) ++ #[← instancesForToHtml i.name])
   | DocInfo.instanceInfo i => equationsToHtml i.toDefinitionInfo
   | DocInfo.classInductiveInfo i => pure #[← classInstancesToHtml i.name]
   | DocInfo.inductiveInfo i => pure #[← instancesForToHtml i.name]


### PR DESCRIPTION
Some defs such as [Lean.RBTree](https://leanprover-community.github.io/mathlib4_docs/Lean/Data/RBTree.html#Lean.RBTree) have instances, this PR adds the "Instances For" dropdown for defs also so we can see them in docs: e.g. in this case this displays as
```
def [Lean.RBTree](http://localhost:1000/Lean/Data/RBTree.html#Lean.RBTree) (α : [Type](http://localhost:1000/foundational_types.html) u) (cmp : α → α → [Ordering](http://localhost:1000/Init/Data/Ord.html#Ordering)) :
[Type](http://localhost:1000/foundational_types.html) u
Equations
Instances For

    [Lean.instInhabitedRBTree](http://localhost:1000/Lean/Data/RBTree.html#Lean.instInhabitedRBTree)
    [Lean.instEmptyCollectionRBTree](http://localhost:1000/Lean/Data/RBTree.html#Lean.instEmptyCollectionRBTree)
    [Lean.RBTree.instForInRBTree](http://localhost:1000/Lean/Data/RBTree.html#Lean.RBTree.instForInRBTree)
    [Lean.RBTree.instReprRBTree](http://localhost:1000/Lean/Data/RBTree.html#Lean.RBTree.instReprRBTree)
```
The downside of this PR is that many defs don't have instances for them, perhaps hiding the instances for dropdown if the list is empty somehow would be better long term