### PR TITLE
feat: don't copy .git folders in test

### DIFF
--- a/test_docs.sh
+++ b/test_docs.sh
@@ -7,7 +7,7 @@ set -x
 
 # carry the already built doc-gen4 over
 mkdir -p "$1"/lake-packages
-cp -r "$2"/lake-packages/* "$1"/lake-packages
+rsync -av --exclude=".*" "$2"/lake-packages/* "$1"/lake-packages
 
 # generate the docs
 cd "$1"


### PR DESCRIPTION
By using rsync in place of cp for more control
The .git folders were causing issues for me (permissions failed for some packed objects on mac) but not copying them seems generally sensible. 