### PR TITLE
feat: trigger search input when event handler is added

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -147,7 +147,8 @@ DeclarationDataCenter.init()
         checkbox.addEventListener("input", ev => SEARCH_PAGE_INPUT.dispatchEvent(new Event("input")))
       );
       SEARCH_PAGE_INPUT.dispatchEvent(new Event("input"))
-    }
+    };
+    SEARCH_INPUT.dispatchEvent(new Event("input"))
   })
   .catch(e => {
     SEARCH_INPUT.addEventListener("input", ev => handleSearch(null, e, ev, ac_results, AC_MAX_RESULTS,true ));


### PR DESCRIPTION
Previously if the user typed something before the data loads and the event handler is added after they would have no way of knowing when the data was loaded and is actually ready to start searching. This plays a role now for mathlib where the data takes a nontrivial amount of time to load.