### PR TITLE
add dark mode

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -40,6 +40,7 @@ def htmlOutputSetup (config : SiteBaseContext) : IO Unit := do
   let docGenStatic := #[
     ("style.css", styleCss),
     ("declaration-data.js", declarationDataCenterJs),
+    ("color-scheme.js", colorSchemeJs),
     ("nav.js", navJs),
     ("how-about.js", howAboutJs),
     ("search.html", searchHtml),

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -148,6 +148,7 @@ are used in documentation generation, notably JS and CSS ones.
 -/
   def styleCss : String := include_str "../../static/style.css"
   def declarationDataCenterJs : String := include_str "../../static/declaration-data.js"
+  def colorSchemeJs : String := include_str "../../static/color-scheme.js"
   def navJs : String := include_str "../../static/nav.js"
   def howAboutJs : String := include_str "../../static/how-about.js"
   def searchJs : String := include_str "../../static/search.js"
@@ -155,7 +156,7 @@ are used in documentation generation, notably JS and CSS ones.
   def importedByJs : String := include_str "../../static/importedBy.js"
   def findJs : String := include_str "../../static/find/find.js"
   def mathjaxConfigJs : String := include_str "../../static/mathjax-config.js"
-  
+
   def alectryonCss : String := include_str "../../static/alectryon/alectryon.css"
   def alectryonJs : String := include_str "../../static/alectryon/alectryon.js"
   def docUtilsCss : String  := include_str "../../static/alectryon/docutils_basic.css"

--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -62,6 +62,7 @@ def navbar : BaseHtmlM Html := do
         [← baseHtmlHeadDeclarations]
 
         <script type="module" src={s!"{← getRoot}nav.js"}></script>
+        <script type="module" src={s!"{← getRoot}color-scheme.js"}></script>
         <base target="_parent" />
       </head>
 
@@ -82,6 +83,18 @@ def navbar : BaseHtmlM Html := do
           -/
           <h3>Library</h3>
           {← moduleList}
+          <div id="settings">
+            -- `input` is a void tag, but can be self-closed to make parsing easier.
+            <h3>Color scheme</h3>
+            <form id="color-theme-switcher">
+                <label for="color-theme-dark">
+                    <input type="radio" name="color_theme" id="color-theme-dark" value="dark" autocomplete="off"/>dark</label>
+                <label for="color-theme-system" title="Match system theme settings">
+                    <input type="radio" name="color_theme" id="color-theme-system" value="system" autocomplete="off"/>system</label>
+                <label for="color-theme-light">
+                    <input type="radio" name="color_theme" id="color-theme-light" value="light" autocomplete="off"/>light</label>
+            </form>
+          </div>
         </nav>
         </div>
       </body>

--- a/DocGen4/Output/Navbar.lean
+++ b/DocGen4/Output/Navbar.lean
@@ -83,7 +83,7 @@ def navbar : BaseHtmlM Html := do
           -/
           <h3>Library</h3>
           {← moduleList}
-          <div id="settings">
+          <div id="settings" hidden="hidden">
             -- `input` is a void tag, but can be self-closed to make parsing easier.
             <h3>Color scheme</h3>
             <form id="color-theme-switcher">

--- a/DocGen4/Process/Hierarchy.lean
+++ b/DocGen4/Process/Hierarchy.lean
@@ -84,6 +84,7 @@ partial def fromArray (names : Array Name) : Hierarchy :=
 def baseDirBlackList : HashSet String :=
   HashSet.fromArray #[
     "404.html",
+    "color-scheme.js",
     "declaration-data.js",
     "declarations",
     "find",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -85,6 +85,7 @@ library_facet docs (lib) : FilePath := do
   let staticFiles := #[
     basePath / "style.css",
     basePath / "declaration-data.js",
+    basePath / "color-scheme.js",
     basePath / "nav.js",
     basePath / "how-about.js",
     basePath / "search.js",

--- a/static/color-scheme.js
+++ b/static/color-scheme.js
@@ -26,3 +26,6 @@ document.addEventListener("DOMContentLoaded", function() {
         setTheme(getTheme());
     })
 });
+
+// un-hide the colorscheme picker
+document.querySelector("#settings").removeAttribute('hidden');

--- a/static/color-scheme.js
+++ b/static/color-scheme.js
@@ -5,10 +5,12 @@ function getTheme() {
 function setTheme(themeName) {
     localStorage.setItem('theme', themeName);
     if (themeName == "system") {
-        themeName = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        themeName = parent.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     }
     // the navbar is in an iframe, so we need to set this variable in the parent document
-    parent.document.documentElement.setAttribute('data-theme', themeName);
+    for (const win of [window, parent]) {
+        win.document.documentElement.setAttribute('data-theme', themeName);
+    }
 }
 
 setTheme(getTheme())
@@ -22,7 +24,7 @@ document.addEventListener("DOMContentLoaded", function() {
     });
 
     // also check to see if the user changes their theme settings while the page is loaded.
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+    parent.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
         setTheme(getTheme());
     })
 });

--- a/static/color-scheme.js
+++ b/static/color-scheme.js
@@ -1,0 +1,28 @@
+function getTheme() {
+    return localStorage.getItem("theme") || "system";
+}
+
+function setTheme(themeName) {
+    localStorage.setItem('theme', themeName);
+    if (themeName == "system") {
+        themeName = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    // the navbar is in an iframe, so we need to set this variable in the parent document
+    parent.document.documentElement.setAttribute('data-theme', themeName);
+}
+
+setTheme(getTheme())
+
+document.addEventListener("DOMContentLoaded", function() {
+    document.querySelectorAll("#color-theme-switcher input").forEach((input) => {
+        if (input.value == getTheme()) {
+            input.checked = true;
+        }
+        input.addEventListener('change', e => setTheme(e.target.value));
+    });
+
+    // also check to see if the user changes their theme settings while the page is loaded.
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        setTheme(getTheme());
+    })
+});

--- a/static/style.css
+++ b/static/style.css
@@ -6,7 +6,14 @@
 
 body {
     font-family: 'Open Sans', sans-serif;
+    color: var(--text-color);
+    background: var(--body-bg);
 }
+
+a {
+   color: var(--link-color);
+}
+
 h1, h2, h3, h4, h5, h6 {
     font-family: 'Merriweather', serif;
 }
@@ -15,11 +22,68 @@ body { line-height: 1.5; }
 nav { line-height: normal; }
 
 :root {
+    color-scheme: light;
     --header-height: 3em;
+    --fragment-offset: calc(var(--header-height) + 1em);
+    --content-width: 55vw;
+
     --header-bg: #f8f8f8;
+    --body-bg: white;
+    --code-bg: #f3f3f3;
+    --text-color: black;
+    --link-color: hsl(210, 100%, 30%);
+
+    --implicit-arg-text-color: var(--text-color);
+
+    --def-color: #92dce5;
+    --def-color-hsl-angle: 187;
+    --theorem-color: #8fe388;
+    --theorem-color-hsl-angle: 115;
+    --axiom-and-constant-color: #f44708;
+    --axiom-and-constant-color-hsl-angle: 16;
+    --structure-and-inductive-color: #f0a202;
+    --structure-and-inductive-color-hsl-angle: 40;
+    --starting-percentage: 100;
+
+    --hamburger-bg-color: #eee;
+    --hamburger-active-color: white;
+    --hamburger-border-color: #ccc;
+
+    --tags-border-color: #555;
+
     --fragment-offset: calc(var(--header-height) + 1em);
     --content-width: 55vw;
 }
+@media (prefers-color-scheme: dark) {
+    :root {
+        color-scheme: dark;
+
+        --header-bg: #111010;
+        --body-bg: #171717;
+        --code-bg: #363333;
+        --text-color: #eee;
+        --link-color: #58a6ff;
+
+        --implicit-arg-text-color: var(--text-color);
+
+        --def-color: #1F497F;
+        --def-color-hsl-angle: 214;
+        --theorem-color: #134E2D;
+        --theorem-color-hsl-angle: 146;
+        --axiom-and-constant-color: #6B1B1A;
+        --axiom-and-constant-color-hsl-angle: 1;
+        --structure-and-inductive-color: #73461C;
+        --structure-and-inductive-color-hsl-angle: 29;
+        --starting-percentage: 30;
+
+        --hamburger-bg-color: #2d2c2c;
+        --hamburger-active-color: black;
+        --hamburger-border-color: #717171;
+
+        --tags-border-color: #AAA;
+    }
+}
+
 @supports (width: min(10px, 5vw)) {
     :root {
         --content-width: clamp(20em, 55vw, 60em);
@@ -94,13 +158,13 @@ header {
     label[for="nav_toggle"] {
         display: inline-block;
         margin-right: 1em;
-        border: 1px solid #ccc;
+        border: 1px solid var(--hamburger-border-color);
         padding: 0.5ex 1ex;
         cursor: pointer;
-        background: #eee;
+        background: var(--hamburger-bg-color);
     }
     #nav_toggle:checked ~ * label[for="nav_toggle"] {
-        background: white;
+        background: var(--hamburger-active-color);
     }
 
     body header h1 {
@@ -199,8 +263,8 @@ header header_filename {
 }
 
 #autocomplete_results .selected .result_link a {
-    background: white;
-    border-color: #f0a202;
+    background: var(--body-bg);
+    border-color: var(--structure-and-inductive-color);
 }
 
 
@@ -413,23 +477,23 @@ main h2, main h3, main h4, main h5, main h6 {
 }
 
 .def, .instance {
-    border-left: 10px solid #92dce5;
-    border-top: 2px solid #92dce5;
+    border-left: 10px solid var(--text-color);
+    border-top: 2px solid var(--text-color);
 }
 
 .theorem {
-    border-left: 10px solid #8fe388;
-    border-top: 2px solid #8fe388;
+    border-left: 10px solid var(--theorem-color);
+    border-top: 2px solid var(--theorem-color);
 }
 
 .axiom, .opaque {
-    border-left: 10px solid #f44708;
-    border-top: 2px solid #f44708;
+    border-left: 10px solid var(--axiom-and-constant-color);
+    border-top: 2px solid var(--axiom-and-constant-color);
 }
 
 .structure, .inductive, .class {
-    border-left: 10px solid #f0a202;
-    border-top: 2px solid #f0a202;
+    border-left: 10px solid var(--structure-and-inductive-color);
+    border-top: 2px solid var(--structure-and-inductive-color);
 }
 
 .fn {
@@ -454,23 +518,23 @@ main h2, main h3, main h4, main h5, main h6 {
 }
 
 .def .fn:hover, .instance .fn:hover {
-    background-color: hsla(187, 61%, calc(100% - 5%*var(--fn)));
-    box-shadow: 0 0 0 1px hsla(187, 61%, calc(100% - 5%*(var(--fn) + 1)));
+    background-color: hsla(var(--def-color-hsl-angle), 61%, calc(var(--starting-percentage) - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(var(--def-color-hsl-angle), 61%, calc(var(--starting-percentage) - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 .theorem .fn:hover {
-    background-color: hsla(115, 62%, calc(100% - 5%*var(--fn)));
-    box-shadow: 0 0 0 1px hsla(115, 62%, calc(100% - 5%*(var(--fn) + 1)));
+    background-color: hsla(var(--theorem-color-hsl-angle), 62%, calc(var(--starting-percentage) - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(var(--theorem-color-hsl-angle), 62%, calc(var(--starting-percentage) - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 .axiom .fn:hover, .opaque .fn:hover {
-    background-color: hsla(16, 94%, calc(100% - 5%*var(--fn)));
-    box-shadow: 0 0 0 1px hsla(16, 94%, calc(100% - 5%*(var(--fn) + 1)));
+    background-color: hsla(var(--axiom-and-constant-color-hsl-angle), 94%, calc(var(--starting-percentage) - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(var(--axiom-and-constant-color-hsl-angle), 94%, calc(var(--starting-percentage) - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 .structure .fn:hover, .inductive .fn:hover, .class .fn:hover {
-    background-color: hsla(40, 98%, calc(100% - 5%*var(--fn)));
-    box-shadow: 0 0 0 1px hsla(40, 98%, calc(100% - 5%*(var(--fn) + 1)));
+    background-color: hsla(var(--structure-and-inductive-color-hsl-angle), 98%, calc(var(--starting-percentage) - 5%*var(--fn)));
+    box-shadow: 0 0 0 1px hsla(var(--structure-and-inductive-color-hsl-angle), 98%, calc(var(--starting-percentage) - 5%*(var(--fn) + 1)));
     border-radius: 5px;
 }
 
@@ -479,7 +543,7 @@ main h2, main h3, main h4, main h5, main h6 {
 }
 
 .implicits, .impl_arg {
-    color: black;
+    color: var(--text-color);
     white-space: normal;
 }
 
@@ -515,7 +579,7 @@ pre {
     white-space: break-spaces;
 }
 
-code, pre { background: #f3f3f3; }
+code, pre { background: var(--code-bg); }
 code, pre { border-radius: 5px; }
 code { padding: 1px 3px; }
 pre { padding: 1ex; }
@@ -574,7 +638,7 @@ pre code { padding: 0 0; }
 
 /** Don't show underline on types, to prevent the ≤ vs < confusion. **/
 a:link, a:visited, a:active {
-    color:hsl(210, 100%, 30%);
+    color:var(--link-color);
     text-decoration: none;
 }
 
@@ -610,7 +674,7 @@ a:hover {
 }
 
 .docfile h2 a {
-    color: black;
+    color: var(--text-color);
 }
 
 .tags {
@@ -623,7 +687,7 @@ a:hover {
 }
 
 .tags li {
-    border: 1px solid #555;
+    border: 1px solid var(--tags-border-color);
     border-radius: 4px;
     list-style-type: none;
     padding: 1px 3px;

--- a/static/style.css
+++ b/static/style.css
@@ -53,7 +53,6 @@ nav { line-height: normal; }
     --fragment-offset: calc(var(--header-height) + 1em);
     --content-width: 55vw;
 }
-
 /* automatic dark theme if no javascript */
 @media (prefers-color-scheme: dark) {
     :root {
@@ -81,6 +80,41 @@ nav { line-height: normal; }
 
         --tags-border-color: #AAA;
     }
+}
+
+[data-theme="light"] {
+    color-scheme: light;
+
+    --header-height: 3em;
+    --fragment-offset: calc(var(--header-height) + 1em);
+    --content-width: 55vw;
+
+    --header-bg: #f8f8f8;
+    --body-bg: white;
+    --code-bg: #f3f3f3;
+    --text-color: black;
+    --link-color: hsl(210, 100%, 30%);
+
+    --implicit-arg-text-color: var(--text-color);
+
+    --def-color: #92dce5;
+    --def-color-hsl-angle: 187;
+    --theorem-color: #8fe388;
+    --theorem-color-hsl-angle: 115;
+    --axiom-and-constant-color: #f44708;
+    --axiom-and-constant-color-hsl-angle: 16;
+    --structure-and-inductive-color: #f0a202;
+    --structure-and-inductive-color-hsl-angle: 40;
+    --starting-percentage: 100;
+
+    --hamburger-bg-color: #eee;
+    --hamburger-active-color: white;
+    --hamburger-border-color: #ccc;
+
+    --tags-border-color: #555;
+
+    --fragment-offset: calc(var(--header-height) + 1em);
+    --content-width: 55vw;
 }
 
 [data-theme="dark"] {

--- a/static/style.css
+++ b/static/style.css
@@ -22,7 +22,6 @@ body { line-height: 1.5; }
 nav { line-height: normal; }
 
 :root {
-    color-scheme: light;
     --header-height: 3em;
     --fragment-offset: calc(var(--header-height) + 1em);
     --content-width: 55vw;
@@ -54,10 +53,10 @@ nav { line-height: normal; }
     --fragment-offset: calc(var(--header-height) + 1em);
     --content-width: 55vw;
 }
+
+/* automatic dark theme if no javascript */
 @media (prefers-color-scheme: dark) {
     :root {
-        color-scheme: dark;
-
         --header-bg: #111010;
         --body-bg: #171717;
         --code-bg: #363333;
@@ -82,6 +81,34 @@ nav { line-height: normal; }
 
         --tags-border-color: #AAA;
     }
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+
+    --header-bg: #111010;
+    --body-bg: #171717;
+    --code-bg: #363333;
+    --text-color: #eee;
+    --link-color: #58a6ff;
+
+    --implicit-arg-text-color: var(--text-color);
+
+    --def-color: #1F497F;
+    --def-color-hsl-angle: 214;
+    --theorem-color: #134E2D;
+    --theorem-color-hsl-angle: 146;
+    --axiom-and-constant-color: #6B1B1A;
+    --axiom-and-constant-color-hsl-angle: 1;
+    --structure-and-inductive-color: #73461C;
+    --structure-and-inductive-color-hsl-angle: 29;
+    --starting-percentage: 30;
+
+    --hamburger-bg-color: #2d2c2c;
+    --hamburger-active-color: black;
+    --hamburger-border-color: #717171;
+
+    --tags-border-color: #AAA;
 }
 
 @supports (width: min(10px, 5vw)) {
@@ -411,6 +438,44 @@ nav {
 
 .navframe {
     --header-height: 0;
+}
+
+#settings {
+    margin-top: 5em;
+}
+#settings h3 {
+    font-size: inherit;
+}
+
+#color-theme-switcher {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 2ex;
+    flex-flow: row wrap;
+}
+
+/* custom radio buttons for dark/light switch */
+#color-theme-switcher input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    display: inline-block;
+    box-sizing: content-box;
+    height: 1em;
+    width: 1em;
+    background-clip: content-box;
+    padding: 2px;
+    border: 2px solid transparent;
+    margin-bottom: -4px;
+    border-radius: 50%;
+}
+#color-theme-dark { background-color: #444; }
+#color-theme-light { background-color: #ccc; }
+#color-theme-system {
+    background-image: linear-gradient(60deg, #444, #444 50%, #CCC 50%, #CCC);
+}
+#color-theme-switcher input:checked {
+    border-color: var(--text-color);
 }
 
 .decl > div, .mod_doc {


### PR DESCRIPTION
This commit adds a dark mode to doc-gen4. It takes much inspiration from leanprover-community/doc-gen#160.
Unlike the dark theme in doc-gen, this will work with or without javascript. If javascript is disabled, the color picker will not work. However, the correct theme will be detected from the browser based on css media queries.
If javascript is enabled, the color picker will work and color picker preferences will be remembered.

note: a dark-mode is not added to inked code. This PR only applies to generated documentation.

closes #117