### PR TITLE
chore: update toolchain

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-17
+leanprover/lean4:nightly-2023-08-19


### PR DESCRIPTION
I wouldn't usually send a bump PR, but `nightly-2023-08-19` is now a tentative release candidate for the first official release of Lean 4, and it would be nice to have everything explicitly test it out!