### PR TITLE
[fix] wrong lean-toolchain version

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:4.0.0
+leanprover/lean4:v4.0.0


### PR DESCRIPTION
Usually, the tags are named with a prefixed v. The same is true for the current releases