### PR TITLE
feat: autolink references to files

### DIFF
--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -70,7 +70,9 @@ partial def xmlGetHeadingId (el : Xml.Element) : String :=
 -/
 def nameToLink? (s : String) : HtmlM (Option String) := do
   let res ← getResult
-  if let some name := Lean.Syntax.decodeNameLit ("`" ++ s) then
+  if s.endsWith ".lean" && s.contains '/' then
+    return (← getRoot) ++ s.dropRight 5 ++ ".html"
+  else if let some name := Lean.Syntax.decodeNameLit ("`" ++ s) then
     -- with exactly the same name
     if res.name2ModIdx.contains name then
       declNameToLink name


### PR DESCRIPTION
mathlib often references other files in docstrings, e.g. in https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Normed/Group/Basic.html#AddMonoidHomClass.lipschitz_of_bound :
![Screenshot from 2023-09-13 21-59-16](https://github.com/leanprover/doc-gen4/assets/65514131/0232b75a-32a5-4409-80e3-d11bdafbf2a1)

It would be helpful if those turned into links.