### PR TITLE
fix: don't fetch unused cache, FF fixes

### DIFF
--- a/static/declaration-data.js
+++ b/static/declaration-data.js
@@ -54,7 +54,12 @@ export class DeclarationDataCenter {
     );
 
     // try to use cache first
-    const data = await fetchCachedDeclarationData().catch(_e => null);
+    // TODO: This API is not thought 100% through. If we have a DB cached
+    // already it will not even ask the remote for a new one so we end up
+    // with outdated declaration-data. This has to have some form of cache
+    // invalidation: https://github.com/leanprover/doc-gen4/issues/133
+    // const data = await fetchCachedDeclarationData().catch(_e => null);
+    const data = null;
     if (data) {
       // if data is defined, use the cached one.
       return new DeclarationDataCenter(data);
@@ -72,7 +77,7 @@ export class DeclarationDataCenter {
    * Search for a declaration.
    * @returns {Array<any>}
    */
-  search(pattern, strict = true, allowedKinds=undefined, maxResults=undefined) {
+  search(pattern, strict = true, allowedKinds = undefined, maxResults = undefined) {
     if (!pattern) {
       return [];
     }
@@ -258,12 +263,7 @@ async function fetchCachedDeclarationData() {
   return new Promise((resolve, reject) => {
     let transactionRequest = store.get(CACHE_DB_KEY);
     transactionRequest.onsuccess = function (event) {
-      // TODO: This API is not thought 100% through. If we have a DB cached
-      // already it will not even ask the remote for a new one so we end up
-      // with outdated declaration-data. This has to have some form of cache
-      // invalidation: https://github.com/leanprover/doc-gen4/issues/133
-      //resolve(event.target.result);
-      resolve(undefined);
+      resolve(event.target.result);
     };
     transactionRequest.onerror = function (event) {
       reject(new Error(`fail to store declaration data`));

--- a/static/find/find.js
+++ b/static/find/find.js
@@ -49,7 +49,7 @@ const queryParams = new Map(
 const fragmentPaths = fragment?.split(LEAN_FRIENDLY_SLASH_SEPARATOR) ?? [];
 
 const encodedPattern = queryParams.get("pattern") ?? fragmentPaths[1]; // if first fail then second, may be undefined
-const pattern = decodeURIComponent(encodedPattern);
+const pattern = encodedPattern && decodeURIComponent(encodedPattern);
 const strict = (queryParams.get("strict") ?? "true") === "true"; // default to true
 const view = fragmentPaths[0];
 


### PR DESCRIPTION
Even though the result of `fetchCachedDeclarationData` was ignored due to #133, we were still performing the request, which takes some time on FF to deserialize (or something), depending on what happened to be on the user's cache (because the cache is never written to, only read). This moves the disabling earlier, so that the cache is not read at all (since this means deserializing an old version of the mathlib JSON data, then ignoring it and fetching another version of the mathlib JSON data).

Also fixes an issue where the `undefined` pattern is passed to `decodeURIComponent` (resulting in `"undefined"` which is mishandled by subsequent code).