### PR TITLE
feat: html escape docstrings

### DIFF
--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -214,7 +214,7 @@ def docStringToHtml (s : String) : HtmlM (Array Html) := do
   match manyDocument rendered.mkIterator with
   | Parsec.ParseResult.success _ res =>
     res.mapM fun x => do return Html.text <| toString (← modifyElement x)
-  | _ => return #[Html.text <| rendered]
+  | _ => return #[Html.text rendered]
 
 end Output
 end DocGen4

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -210,11 +210,11 @@ partial def modifyElement (element : Element) : HtmlM Element :=
 
 /-- Convert docstring to Html. -/
 def docStringToHtml (s : String) : HtmlM (Array Html) := do
-  let rendered := CMark.renderHtml s
+  let rendered := CMark.renderHtml (Html.escape s)
   match manyDocument rendered.mkIterator with
   | Parsec.ParseResult.success _ res =>
     res.mapM fun x => do return Html.text <| toString (← modifyElement x)
-  | _ => return #[Html.text rendered]
+  | _ => return #[Html.text <| rendered]
 
 end Output
 end DocGen4

--- a/DocGen4/Output/ToHtmlFormat.lean
+++ b/DocGen4/Output/ToHtmlFormat.lean
@@ -53,10 +53,10 @@ partial def textLength : Html → Nat
 
 def escapePairs : Array (String × String) :=
   #[
-    ("&", "&amp"),
-    ("<", "&lt"),
-    (">", "&gt"),
-    ("\"", "&quot")
+    ("&", "&amp;"),
+    ("<", "&lt;"),
+    (">", "&gt;"),
+    ("\"", "&quot;")
   ]
 
 def escape (s : String) : String :=


### PR DESCRIPTION
also fix the escape codes

see https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/ConditionallyCompleteLattice/Basic.html#ciSup_le for examples of why this is needed