### PR TITLE
feat: Add support for `vscode://file/` source links

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -80,10 +80,10 @@ def htmlOutputDeclarationDatas (result : AnalyzerResult) : HtmlT IO Unit := do
     let jsonDecls ← Module.toJson mod
     FS.writeFile (declarationsBasePath / s!"declaration-data-{mod.name}.bmp") (toJson jsonDecls).compress
 
-def htmlOutputResults (baseConfig : SiteBaseContext) (result : AnalyzerResult) (gitUrl? : Option String) (ink : Bool) : IO Unit := do
+def htmlOutputResults (baseConfig : SiteBaseContext) (result : AnalyzerResult) (sourceUrl? : Option String) (ink : Bool) : IO Unit := do
   let config : SiteContext := {
     result := result,
-    sourceLinker := ← SourceLinker.sourceLinker gitUrl?
+    sourceLinker := SourceLinker.sourceLinker sourceUrl?
     leanInkEnabled := ink
   }
 
@@ -144,10 +144,9 @@ def htmlOutputIndex (baseConfig : SiteBaseContext) : IO Unit := do
 The main entrypoint for outputting the documentation HTML based on an
 `AnalyzerResult`.
 -/
-def htmlOutput (result : AnalyzerResult) (hierarchy : Hierarchy) (gitUrl? : Option String) (ink : Bool) : IO Unit := do
+def htmlOutput (result : AnalyzerResult) (hierarchy : Hierarchy) (sourceUrl? : Option String) (ink : Bool) : IO Unit := do
   let baseConfig ← getSimpleBaseContext hierarchy
-  htmlOutputResults baseConfig result gitUrl? ink
+  htmlOutputResults baseConfig result sourceUrl? ink
   htmlOutputIndex baseConfig
 
 end DocGen4
-

--- a/DocGen4/Output/SourceLinker.lean
+++ b/DocGen4/Output/SourceLinker.lean
@@ -31,19 +31,22 @@ def sourceLinker (gitUrl? : Option String) (module : Name) : Option DeclarationR
   let leanHash := Lean.githash
   if root == `Lean ∨ root == `Init then
     let parts := module.components.map Name.toString
-    let path := String.intercalate "/" parts
+    let path := "/".intercalate parts
     mkGithubSourceLinker s!"https://github.com/leanprover/lean4/blob/{leanHash}/src/{path}.lean"
   else if root == `Lake then
     let parts := module.components.map Name.toString
-    let path := String.intercalate "/" parts
+    let path := "/".intercalate parts
     mkGithubSourceLinker s!"https://github.com/leanprover/lean4/blob/{leanHash}/src/lake/{path}.lean"
   else
     match gitUrl? with
     | .some url =>
       if url.startsWith "vscode://file/" then
         mkVscodeSourceLinker url
-      else
+      else if url.startsWith "https://github.com" then
         mkGithubSourceLinker url
+      else
+        -- Other urls do not have range added.
+        fun _ => url
     | .none => panic! s!"Github URL must be defined for {module}."
 
 end DocGen4.Output.SourceLinker

--- a/DocGen4/Output/SourceLinker.lean
+++ b/DocGen4/Output/SourceLinker.lean
@@ -16,8 +16,9 @@ def mkGithubSourceLinker (baseUrl : String) (range : Option DeclarationRange) : 
 
 def mkVscodeSourceLinker (baseUrl : String) (range : Option DeclarationRange) : String :=
   match range with
-  -- Note. We may want to verify Lean line and column numbers match VSCode.
-  | some range => s!"{baseUrl}:{range.pos.line}:{range.pos.column}"
+  -- Note. We may want to verify Lean column numbers match VSCode on complex unicode
+  -- characters.  There could be encoding mismatches.
+  | some range => s!"{baseUrl}:{range.pos.line}:{range.pos.column+1}"
   | none => baseUrl
 
 /--

--- a/DocGen4/Output/SourceLinker.lean
+++ b/DocGen4/Output/SourceLinker.lean
@@ -9,28 +9,40 @@ namespace DocGen4.Output.SourceLinker
 
 open Lean
 
+def mkGithubSourceLinker (baseUrl : String) (range : Option DeclarationRange) : String :=
+  match range with
+  | some range => s!"{baseUrl}#L{range.pos.line}-L{range.endPos.line}"
+  | none => baseUrl
+
+def mkVscodeSourceLinker (baseUrl : String) (range : Option DeclarationRange) : String :=
+  match range with
+  -- Note. We may want to verify Lean line and column numbers match VSCode.
+  | some range => s!"{baseUrl}:{range.pos.line}:{range.pos.column}"
+  | none => baseUrl
+
 /--
 Given a lake workspace with all the dependencies as well as the hash of the
 compiler release to work with this provides a function to turn names of
 declarations into (optionally positional) Github URLs.
 -/
-def sourceLinker (gitUrl? : Option String) : IO (Name → Option DeclarationRange → String) := do
-  -- TOOD: Refactor this, we don't need to pass in the module into the returned closure
-  -- since we have one sourceLinker per module
-  return fun module range =>
+def sourceLinker (gitUrl? : Option String) (module : Name) : Option DeclarationRange → String :=
+  let root := module.getRoot
+  let leanHash := Lean.githash
+  if root == `Lean ∨ root == `Init then
     let parts := module.components.map Name.toString
     let path := String.intercalate "/" parts
-    let root := module.getRoot
-    let leanHash := Lean.githash
-    let basic := if root == `Lean ∨ root == `Init then
-      s!"https://github.com/leanprover/lean4/blob/{leanHash}/src/{path}.lean"
-    else if root == `Lake then
-      s!"https://github.com/leanprover/lean4/blob/{leanHash}/src/lake/{path}.lean"
-    else
-      gitUrl?.get!
-
-    match range with
-    | some range => s!"{basic}#L{range.pos.line}-L{range.endPos.line}"
-    | none => basic
+    mkGithubSourceLinker s!"https://github.com/leanprover/lean4/blob/{leanHash}/src/{path}.lean"
+  else if root == `Lake then
+    let parts := module.components.map Name.toString
+    let path := String.intercalate "/" parts
+    mkGithubSourceLinker s!"https://github.com/leanprover/lean4/blob/{leanHash}/src/lake/{path}.lean"
+  else
+    match gitUrl? with
+    | .some url =>
+      if url.startsWith "vscode://file/" then
+        mkVscodeSourceLinker url
+      else
+        mkGithubSourceLinker url
+    | .none => panic! s!"Github URL must be defined for {module}."
 
 end DocGen4.Output.SourceLinker

--- a/Main.lean
+++ b/Main.lean
@@ -12,10 +12,10 @@ def getTopLevelModules (p : Parsed) : IO (List String) :=  do
 
 def runSingleCmd (p : Parsed) : IO UInt32 := do
   let relevantModules := #[p.positionalArg! "module" |>.as! String |> String.toName]
-  let sourceUrl := p.positionalArg! "sourceUrl" |>.as! String
+  let sourceUri := p.positionalArg! "sourceUri" |>.as! String
   let (doc, hierarchy) ← load <| .loadAllLimitAnalysis relevantModules
   let baseConfig ← getSimpleBaseContext hierarchy
-  htmlOutputResults baseConfig doc (some sourceUrl) (p.hasFlag "ink")
+  htmlOutputResults baseConfig doc (some sourceUri) (p.hasFlag "ink")
   return 0
 
 def runIndexCmd (_p : Parsed) : IO UInt32 := do
@@ -44,7 +44,7 @@ def singleCmd := `[Cli|
 
   ARGS:
     module : String; "The module to generate the HTML for. Does not have to be part of topLevelModules."
-    sourceUrl : String; "The sourceUrl as computed by the Lake facet"
+    sourceUri : String; "The sourceUri as computed by the Lake facet"
 ]
 
 def indexCmd := `[Cli|

--- a/Main.lean
+++ b/Main.lean
@@ -44,7 +44,7 @@ def singleCmd := `[Cli|
 
   ARGS:
     module : String; "The module to generate the HTML for. Does not have to be part of topLevelModules."
-    gitUrl : String; "The gitUrl as computed by the Lake facet"
+    sourceUrl : String; "The sourceUrl as computed by the Lake facet"
 ]
 
 def indexCmd := `[Cli|

--- a/Main.lean
+++ b/Main.lean
@@ -12,10 +12,10 @@ def getTopLevelModules (p : Parsed) : IO (List String) :=  do
 
 def runSingleCmd (p : Parsed) : IO UInt32 := do
   let relevantModules := #[p.positionalArg! "module" |>.as! String |> String.toName]
-  let gitUrl := p.positionalArg! "gitUrl" |>.as! String
+  let sourceUrl := p.positionalArg! "sourceUrl" |>.as! String
   let (doc, hierarchy) ← load <| .loadAllLimitAnalysis relevantModules
   let baseConfig ← getSimpleBaseContext hierarchy
-  htmlOutputResults baseConfig doc (some gitUrl) (p.hasFlag "ink")
+  htmlOutputResults baseConfig doc (some sourceUrl) (p.hasFlag "ink")
   return 0
 
 def runIndexCmd (_p : Parsed) : IO UInt32 := do
@@ -27,7 +27,7 @@ def runIndexCmd (_p : Parsed) : IO UInt32 := do
 def runGenCoreCmd (_p : Parsed) : IO UInt32 := do
   let (doc, hierarchy) ← loadCore
   let baseConfig ← getSimpleBaseContext hierarchy
-  htmlOutputResults baseConfig doc none (ink := False) 
+  htmlOutputResults baseConfig doc none (ink := False)
   return 0
 
 def runDocGenCmd (_p : Parsed) : IO UInt32 := do

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ Note that we do not recommend this approach and suggest to instead make sure you
 projects always compile by using CI to prevent broken code from being added and `sorry`-ing
 out things that you intend to complete later.
 
+## Source locations
+
+Source locations default to guessing the Github repo for the library, but different different schemas can be used by setting the `DOCGEN_SOURCE` environment variable.  For
+example, one can use links that open the local source file in VSCode by running lake with:
+```
+DOCGEN_SOURCE="vscode" lake -R -Kenv=dev ...
+```
+
+The different options are:
+
+ * `DOCGEN_SOURCE="github"` infers the
+   Github project for each library and uses source links to the Github source view.
+   This is the default if `DOCGEN_SOURCE` is unset.
+ * `DOCGEN_SOURCE="file"` creates references to local file references.
+ * `DOCGEN_SOURCE="vscode"` creates [VSCode URLs](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls) to local files.
+
 ## How does `docs#Nat.add` from the Lean Zulip work?
 If someone sends a message that contains `docs#Nat.add` on the Lean Zulip this will
 automatically link to `Nat.add` from the `mathlib4` documentation. The way that this


### PR DESCRIPTION
This makes some changes to source code url resolution to allow `vscode://file/` urls.  I find this useful for quickly jumping to the source code when browsing locally generated documentation.

This changes the default is to use VSCode urls if the git repo has changed.  This may not be the right approach.  We could further generalize how resolution occurs, but  I thought I'd submit the PR and start a discussion.
