### PR TITLE
Remove fixed font-size

### DIFF
--- a/DocGen4/Output/Index.lean
+++ b/DocGen4/Output/Index.lean
@@ -15,7 +15,9 @@ def index : BaseHtmlM Html := do templateExtends (baseHtml "Index") <|
   pure <|
     <main>
       <a id="top"></a>
-      <h1> Welcome to the documentation page </h1>
+      <h1> Mathlib4 Documentation </h1>
+      <p>This is the API reference for mathlib 3, the library of mathematics developed for Lean 3. If you need information about installing Lean or mathlib, or getting started with a project, please visit our <a href="https://leanprover-community.github.io">community website</a></p>
+      <p>For the now deprecated Lean 3 version, see <a href="https://leanprover-community.github.io/mathlib_docs">mathlib3's documentation</a>.</p>
       -- Temporary comment until the lake issue is resolved
       -- for commit <a href={s!"{← getProjectGithubUrl}/tree/{← getProjectCommit}"}>{s!"{← getProjectCommit} "}</a>
       <p>This was built using Lean 4 at commit <a href={s!"https://github.com/leanprover/lean4/tree/{Lean.githash}"}>{Lean.githash}</a></p>

--- a/DocGen4/Output/Index.lean
+++ b/DocGen4/Output/Index.lean
@@ -15,9 +15,7 @@ def index : BaseHtmlM Html := do templateExtends (baseHtml "Index") <|
   pure <|
     <main>
       <a id="top"></a>
-      <h1> Mathlib4 Documentation </h1>
-      <p>This is the API reference for mathlib 3, the library of mathematics developed for Lean 3. If you need information about installing Lean or mathlib, or getting started with a project, please visit our <a href="https://leanprover-community.github.io">community website</a></p>
-      <p>For the now deprecated Lean 3 version, see <a href="https://leanprover-community.github.io/mathlib_docs">mathlib3's documentation</a>.</p>
+      <h1> Welcome to the documentation page </h1>
       -- Temporary comment until the lake issue is resolved
       -- for commit <a href={s!"{← getProjectGithubUrl}/tree/{← getProjectCommit}"}>{s!"{← getProjectCommit} "}</a>
       <p>This was built using Lean 4 at commit <a href={s!"https://github.com/leanprover/lean4/tree/{Lean.githash}"}>{Lean.githash}</a></p>

--- a/DocGen4/Output/Module.lean
+++ b/DocGen4/Output/Module.lean
@@ -186,7 +186,7 @@ Render the internal nav bar (the thing on the right on all module pages).
 def internalNav (members : Array Name) (moduleName : Name) : HtmlM Html := do
   pure
     <nav class="internal_nav">
-      <h3><a class="break_within" href="#top">[breakWithin moduleName.toString]</a></h3>
+      <p><a href="#top">return to top</a></p>
       <p class="gh_nav_link"><a href={← getSourceUrl moduleName none}>source</a></p>
       <div class="imports">
         <details>

--- a/DocGen4/Output/Template.lean
+++ b/DocGen4/Output/Template.lean
@@ -45,8 +45,8 @@ def baseHtmlGenerator (title : String) (site : Array Html) : BaseHtmlM Html := d
         <input id="nav_toggle" type="checkbox"/>
 
         <header>
-          <h1><label for="nav_toggle"></label>Documentation</h1>
-          <p class="header_filename break_within">[breakWithin title]</p>
+          <h2><label for="nav_toggle"></label>Mathlib4</h2>
+          <h4 class="header_filename break_within">[breakWithin title]</h4>
           <form action="https://google.com/search" method="get" id="search_form">
             <input type="hidden" name="sitesearch" value="https://leanprover-community.github.io/mathlib4_docs"/>
             <input type="text" name="q" autocomplete="off"/>&#32;

--- a/DocGen4/Output/Template.lean
+++ b/DocGen4/Output/Template.lean
@@ -45,8 +45,8 @@ def baseHtmlGenerator (title : String) (site : Array Html) : BaseHtmlM Html := d
         <input id="nav_toggle" type="checkbox"/>
 
         <header>
-          <h2><label for="nav_toggle"></label>Mathlib4</h2>
-          <h4 class="header_filename break_within">[breakWithin title]</h4>
+          <h1><label for="nav_toggle"></label>Documentation</h1>
+          <h2 class="header_filename break_within">[breakWithin title]</h2>
           <form action="https://google.com/search" method="get" id="search_form">
             <input type="hidden" name="sitesearch" value="https://leanprover-community.github.io/mathlib4_docs"/>
             <input type="text" name="q" autocomplete="off"/>&#32;

--- a/static/style.css
+++ b/static/style.css
@@ -172,7 +172,7 @@ header {
     left: 0;
     right: 0;
     top: 0;
-    --header-side-padding: 2em;
+    --header-side-padding: 1em;
     padding: 0 var(--header-side-padding);
     background: var(--header-bg);
     z-index: 1;
@@ -182,7 +182,7 @@ header {
 }
 @supports (width: min(10px, 5vw)) {
     header {
-        --header-side-padding: calc(max(2em, (100vw - var(--content-width) - 30em) / 2));
+        --header-side-padding: calc(max(1em, (100vw - var(--content-width) - 30em) / 2));
     }
 }
 @media screen and (max-width: 1000px) {
@@ -257,7 +257,7 @@ header {
 header > * {
     display: inline-block;
     padding: 0;
-    margin: 0 1em;
+    margin: 0;
     vertical-align: middle;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -261,13 +261,10 @@ header > * {
     vertical-align: middle;
 }
 
-header h1 {
-    font-weight: normal;
-    font-size: 160%;
-}
-
-header header_filename {
-    font-size: 150%;
+header .header_filename {
+    color: gray;
+    text-align: center;
+    line-height: 95%;
 }
 @media (max-width: 80em) {
     .header .header_filename {

--- a/static/style.css
+++ b/static/style.css
@@ -570,7 +570,8 @@ https://bugs.webkit.org/show_bug.cgi?id=189265
 }
 
 main h2, main h3, main h4, main h5, main h6 {
-    margin-top: 2rem;
+    margin-top: 1rem;
+    margin-bottom: -0.4rem;
 }
 .decl + .mod_doc > h2,
         .decl + .mod_doc > h3,

--- a/static/style.css
+++ b/static/style.css
@@ -267,7 +267,7 @@ header .header_filename {
     line-height: 95%;
 }
 @media (max-width: 80em) {
-    .header .header_filename {
+    header .header_filename {
         display: none;
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -261,7 +261,13 @@ header > * {
     vertical-align: middle;
 }
 
+header h1 {
+    font-weight: normal;
+    font-size: 1.5em;
+}
+
 header .header_filename {
+    font-size: 17px;
     color: gray;
     text-align: center;
     line-height: 95%;

--- a/static/style.css
+++ b/static/style.css
@@ -21,7 +21,6 @@ a {
 
 h1, h2, h3, h4, h5, h6 {
     font-family: 'Lato Medium';
-    font-size: 17px;
 }
 
 body { line-height: 1.5; }
@@ -677,7 +676,7 @@ main h2, main h3, main h4, main h5, main h6 {
 
 .imports li, code, .decl_header, .attributes, .structure_field_info,
         .constructor, .instances li, .instances-for-list li, .equation, .structure_ext_ctor {
-    font-size: 16px;
+    font-size: 92%;
     font-family: 'JuliaMono', monospace;
 }
 


### PR DESCRIPTION
* Visual hierarchy of the `h1, h2`, etc. elements is important. I remove the `17px` fixed `font-size` for section title elements and adjust code `font-size` to a relative `92%`. I also adjust the spacing a little.
* ~~Mention `mathlib4` on the home page. Add link to point to community page and `mathlib3` docs.~~
* ~~The biggest text on the top left should be `Mathlib4` rather than the non-descriptive `Documentation`. Size adjusted to `h2`.~~
* The file name shown at the top is now grey to reduce visual fatigue. Size adjusted to `h2`, centre aligned. Line height changed to 95% to fit better when wrapped.
* Fixed a couple typos, where `.header` is used in the CSS selector instead of `header`.
* Replace the repeated file name on the top right with a "return to top" link.