### PR TITLE
fix: `<url>` processing of markdown

### DIFF
--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -208,6 +208,9 @@ partial def modifyElement (element : Element) : HtmlM Element :=
         | _ => pure c
       return ⟨ name, attrs, newContents ⟩
 
+-- TODO: remove the following 3 functions
+-- once <https://github.com/leanprover/lean4/issues/4411> is fixed
+
 private def _root_.Lean.Xml.Attributes.toStringEscaped (as : Attributes) : String :=
   as.fold (fun s n v => s ++ s!" {n}=\"{Html.escape v}\"") ""
 
@@ -228,6 +231,8 @@ def docStringToHtml (s : String) : HtmlM (Array Html) := do
   let rendered := CMark.renderHtml s
   match manyDocument rendered.mkIterator with
   | Parsec.ParseResult.success _ res =>
+    -- TODO: use `toString` instead of `eToStringEscaped`
+    -- once <https://github.com/leanprover/lean4/issues/4411> is fixed
     res.mapM fun x => do return Html.text <| eToStringEscaped (← modifyElement x)
   | _ => return #[Html.text rendered]
 


### PR DESCRIPTION
This PR fixes `<url>` processing problem of markdown introduced by #157. It turns out that the problem occurred at `Lean.Xml.instToStringElement` which does not do escape. The code is copied from `Lean.Xml.instToStringElement` with escape code added. The added functions should be removed once https://github.com/leanprover/lean4/issues/4411 is fixed.

discussion: <https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Contribution.20to.20doc-gen4.3F/near/443537944>