### PR TITLE
fix: escape html correctly

### DIFF
--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -224,7 +224,7 @@ to as much information as possible.
 -/
 partial def infoFormatToHtml (i : CodeWithInfos) : HtmlM (Array Html) := do
   match i with
-  | .text t => return #[Html.escape t]
+  | .text t => return #[t]
   | .append tt => tt.foldlM (fun acc t => do return acc ++ (← infoFormatToHtml t)) #[]
   | .tag a t =>
     match a.info.val.info with
@@ -237,7 +237,7 @@ partial def infoFormatToHtml (i : CodeWithInfos) : HtmlM (Array Html) := do
         if (← getResult).name2ModIdx.contains name then
           match t with
           | .text t =>
-            let (front, t, back) := splitWhitespaces <| Html.escape t
+            let (front, t, back) := splitWhitespaces t
             let elem := <a href={← declNameToLink name}>{t}</a>
             return #[Html.text front, elem, Html.text back]
           | _ =>

--- a/DocGen4/Output/DocString.lean
+++ b/DocGen4/Output/DocString.lean
@@ -233,8 +233,8 @@ def docStringToHtml (s : String) : HtmlM (Array Html) := do
   | Parsec.ParseResult.success _ res =>
     -- TODO: use `toString` instead of `eToStringEscaped`
     -- once <https://github.com/leanprover/lean4/issues/4411> is fixed
-    res.mapM fun x => do return Html.text <| eToStringEscaped (← modifyElement x)
-  | _ => return #[Html.text rendered]
+    res.mapM fun x => do return Html.raw <| eToStringEscaped (← modifyElement x)
+  | _ => return #[Html.raw rendered]
 
 end Output
 end DocGen4

--- a/DocGen4/Output/ToHtmlFormat.lean
+++ b/DocGen4/Output/ToHtmlFormat.lean
@@ -20,36 +20,16 @@ inductive Html where
   -- TODO(WN): it's nameless for shorter JSON; re-add names when we have deriving strategies for From/ToJson
   -- element (tag : String) (flatten : Bool) (attrs : Array HtmlAttribute) (children : Array Html)
   | element : String → Bool → Array (String × String) → Array Html → Html
+  /-- A text node, which will be escaped in the output -/
   | text : String → Html
+  /-- An arbitrary string containing HTML -/
+  | raw : String → Html
   deriving Repr, BEq, Inhabited, FromJson, ToJson
 
 instance : Coe String Html :=
   ⟨Html.text⟩
 
 namespace Html
-
-def attributesToString (attrs : Array (String × String)) :String :=
-  attrs.foldl (fun acc (k, v) => acc ++ " " ++ k ++ "=\"" ++ v ++ "\"") ""
-
--- TODO: Termination proof
-partial def toStringAux : Html → String
-| element tag false attrs #[text s] => s!"<{tag}{attributesToString attrs}>{s}</{tag}>\n"
-| element tag false attrs #[child] => s!"<{tag}{attributesToString attrs}>\n{child.toStringAux}</{tag}>\n"
-| element tag false attrs children => s!"<{tag}{attributesToString attrs}>\n{children.foldl (· ++ toStringAux ·) ""}</{tag}>\n"
-| element tag true attrs children => s!"<{tag}{attributesToString attrs}>{children.foldl (· ++ toStringAux ·) ""}</{tag}>"
-| text s => s
-
-def toString (html : Html) : String :=
-  html.toStringAux.trimRight
-
-instance : ToString Html :=
-  ⟨toString⟩
-
-partial def textLength : Html → Nat
-| text s => s.length
-| element _ _ _ children =>
-  let lengths := children.map textLength
-  lengths.foldl Nat.add 0
 
 def escapePairs : Array (String × String) :=
   #[
@@ -61,6 +41,29 @@ def escapePairs : Array (String × String) :=
 
 def escape (s : String) : String :=
   escapePairs.foldl (fun acc (o, r) => acc.replace o r) s
+
+def attributesToString (attrs : Array (String × String)) :String :=
+  attrs.foldl (fun acc (k, v) => acc ++ " " ++ k ++ "=\"" ++ escape v ++ "\"") ""
+
+-- TODO: Termination proof
+partial def toStringAux : Html → String
+| element tag false attrs #[text s] => s!"<{tag}{attributesToString attrs}>{escape s}</{tag}>\n"
+| element tag false attrs #[raw s] => s!"<{tag}{attributesToString attrs}>{s}</{tag}>\n"
+| element tag false attrs #[child] => s!"<{tag}{attributesToString attrs}>\n{child.toStringAux}</{tag}>\n"
+| element tag false attrs children => s!"<{tag}{attributesToString attrs}>\n{children.foldl (· ++ toStringAux ·) ""}</{tag}>\n"
+| element tag true attrs children => s!"<{tag}{attributesToString attrs}>{children.foldl (· ++ toStringAux ·) ""}</{tag}>"
+| text s => escape s
+| raw s => s
+
+def toString (html : Html) : String :=
+  html.toStringAux.trimRight
+
+partial def textLength : Html → Nat
+| raw s => s.length  -- measures lengths of escape sequences too!
+| text s => s.length
+| element _ _ _ children =>
+  let lengths := children.map textLength
+  lengths.foldl Nat.add 0
 
 end Html
 


### PR DESCRIPTION
The `.text` constructor was a misnomer, as this was not a "text node" in the sense that HTML/DOM defines the phrase.

This introduces a `raw` constructor, which it appears is only needed in one place.