### PR TITLE
Update Template.lean to remove poisioned polyfill.io

### DIFF
--- a/DocGen4/Output/Template.lean
+++ b/DocGen4/Output/Template.lean
@@ -27,7 +27,7 @@ def baseHtmlGenerator (title : String) (site : Array Html) : BaseHtmlM Html := d
 
         <title>{title}</title>
         <script defer="true" src={s!"{← getRoot}mathjax-config.js"}></script>
-        <script defer="true" src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+        <script defer="true" src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
         <script defer="true" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
         <script>{.raw s!"const SITE_ROOT={String.quote (← getRoot)};"}</script>


### PR DESCRIPTION
Recently, polyfill.io, a well-known service for dynamically supplying polyfills for various browsers, has been the target of a supply chain attack. Numerous security researchers have confirmed the presence of malicious code within the JavaScripts provided by polyfill.io. This pull request proposes an alternative service URL from Cloudflare to replace the compromised domain.

References:

- https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack
- https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk