### PR TITLE
feat: use the core signature delaborator

### DIFF
--- a/DocGen4/Output/Module.lean
+++ b/DocGen4/Output/Module.lean
@@ -25,20 +25,10 @@ Render an `Arg` as HTML, adding opacity effects etc. depending on what
 type of binder it has.
 -/
 def argToHtml (arg : Arg) : HtmlM Html := do
-  let (l, r, implicit) := match arg.binderInfo with
-  | BinderInfo.default => ("(", ")", false)
-  | BinderInfo.implicit => ("{", "}", true)
-  | BinderInfo.strictImplicit => ("⦃", "⦄", true)
-  | BinderInfo.instImplicit => ("[", "]", true)
-  let mut nodes :=
-    match arg.name with
-    | some name => #[Html.text s!"{l}{name.toString} : "]
-    | none => #[Html.text s!"{l}"]
-  nodes := nodes.append (← infoFormatToHtml arg.type)
-  nodes := nodes.push r
-  let inner := <span class="fn">[nodes]</span>
+  let node ← infoFormatToHtml arg.binder
+  let inner := <span class="fn">[node]</span>
   let html := Html.element "span" false #[("class", "decl_args")] #[inner]
-  if implicit then
+  if arg.implicit then
     return <span class="impl_arg">{html}</span>
   else
     return html

--- a/DocGen4/Process/Base.lean
+++ b/DocGen4/Process/Base.lean
@@ -33,18 +33,13 @@ An argument to a declaration, e.g. the `(x : Nat)` in `def foo (x : Nat) := x`.
 -/
 structure Arg where
   /--
-  The name of the argument. For auto generated argument names like `[Monad α]`
-  this is none
+  The pretty printed binder syntax itself.
   -/
-  name : Option Name
+  binder : CodeWithInfos
   /--
-  The pretty printed type of the argument.
+  Whether the binder is implicit.
   -/
-  type : CodeWithInfos
-  /--
-  What kind of binder was used for the argument.
-  -/
-  binderInfo : BinderInfo
+  implicit : Bool
 
 /--
 A base structure for information about a declaration.


### PR DESCRIPTION
This PR makes use of the core signature delaborator to pretty print signatures. This fixes some bugs and brings the output in line with `#check`.

For example:
- Now binders are grouped.
- Now it uses the same heuristics as `#check` for what comes before and after the colon.
- Now the bug [reported in this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/docgen.20strange.20daggers/near/481964331) is fixed, where daggers appeared in the incorrect positions.