### PR TITLE
fix: resolve build issues with mathlib

### DIFF
--- a/DocGen4/Load.lean
+++ b/DocGen4/Load.lean
@@ -11,7 +11,7 @@ open Lean System IO
 
 def envOfImports (imports : Array Name) : IO Environment := do
   -- needed for modules which use syntax registered with `initialize add_parser_alias ..`
-  Lean.enableInitializersExecution
+  unsafe Lean.enableInitializersExecution
   importModules (imports.map (Import.mk · false)) Options.empty (leakEnv := true)
 
 def loadInit (imports : Array Name) : IO Hierarchy := do

--- a/DocGen4/Load.lean
+++ b/DocGen4/Load.lean
@@ -10,7 +10,9 @@ namespace DocGen4
 open Lean System IO
 
 def envOfImports (imports : Array Name) : IO Environment := do
- importModules (imports.map (Import.mk · false)) Options.empty (leakEnv := true)
+  -- needed for modules which use syntax registered with `initialize add_parser_alias ..`
+  Lean.enableInitializersExecution
+  importModules (imports.map (Import.mk · false)) Options.empty (leakEnv := true)
 
 def loadInit (imports : Array Name) : IO Hierarchy := do
  let env ← envOfImports imports


### PR DESCRIPTION
See https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/lean4checker.20failure/near/486823143 for more details.

If initializers don't run, then the parsers registered with `initlialize add_parser_alias ..` do not run, and so the alias never exists and the downstream code that references the alias crashes.

`import-graph` and the Batteries linter framework already include this line.

I have not tested if this actually resolves the mathlib build issue,