### PR TITLE
chore: make CI fail if we panic

### DIFF
--- a/test_docs.sh
+++ b/test_docs.sh
@@ -12,5 +12,7 @@ name = "«doc-gen4»"
 path = "../doc-gen4"
 EOL
 
+export LEAN_ABORT_ON_PANIC=1
+
 lake update doc-gen4
 lake build Batteries:docs


### PR DESCRIPTION
This can only be merged after #[6374](https://github.com/leanprover/lean4/issues/6374) is fixed.