### PR TITLE
feat: abbreviate names based on the namespace of the declaration

### DIFF
--- a/DocGen4/Process/NameInfo.lean
+++ b/DocGen4/Process/NameInfo.lean
@@ -50,7 +50,8 @@ def Info.ofTypedName (n : Name) (t : Expr) : MetaM Info := do
   -- Use the main signature delaborator. We need to run sanitization, parenthesization, and formatting ourselves
   -- to be able to extract the pieces of the signature right before they are formatted
   -- and then format them individually.
-  let (sigStx, infos) ← PrettyPrinter.delabCore t (delab := PrettyPrinter.Delaborator.delabConstWithSignature.delabParams {} default #[])
+  let (sigStx, infos) ← withTheReader Core.Context ({ · with currNamespace := n.getPrefix }) <|
+    PrettyPrinter.delabCore t (delab := PrettyPrinter.Delaborator.delabConstWithSignature.delabParams {} default #[])
   let sigStx := (sanitizeSyntax sigStx).run' { options := (← getOptions) }
   let sigStx ← PrettyPrinter.parenthesize PrettyPrinter.Delaborator.declSigWithId.parenthesizer sigStx
   let `(PrettyPrinter.Delaborator.declSigWithId| $_:term $binders* : $type) := sigStx


### PR DESCRIPTION
This PR renders signatures in the namespace of the declaration, which causes non-protected names in that namespace or any parent namespace to be abbreviated. The result is shorter signatures which can be much easier to read, though this could potentially be confusing for users who do not have the namespace open.
Before:
![old](https://github.com/user-attachments/assets/4ae3a383-eb67-41b7-8b2b-41dd0490aa72)
After:
![new](https://github.com/user-attachments/assets/d0611023-32a3-4ff4-a8c6-1c8fa660de5f)
