### PR TITLE
feat: add option to disable equation generation for definitions

### DIFF
--- a/DocGen4/Process/DefinitionInfo.lean
+++ b/DocGen4/Process/DefinitionInfo.lean
@@ -30,7 +30,7 @@ def processEq (eq : Name) : MetaM CodeWithInfos := do
 def computeEquations? (v : DefinitionVal) : MetaM (Array CodeWithInfos) := do
   -- TODO: consider checking this in a more principled way, and wrapping things by some Reader
   match ← IO.getEnv "DISABLE_EQUATIONS" with
-  | some "0" => return #[]
+  | some "1" => return #[]
   | _ =>
     let eqs? ← getEqnsFor? v.name
     match eqs? with

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The different options are:
  * `DOCGEN_SRC="vscode"` creates [VSCode URLs](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls) to local files.
 
 ## Disabling equations
-Generation of equations for definitions is enabled by default, but can be disabled by setting the `DISABLE_EQUATIONS` environment variable to `0`.
+Generation of equations for definitions is enabled by default, but can be disabled by setting the `DISABLE_EQUATIONS` environment variable to `1`.
 
 ## How does `docs#Nat.add` from the Lean Zulip work?
 If someone sends a message that contains `docs#Nat.add` on the Lean Zulip this will


### PR DESCRIPTION
This PR allows generation of equations for definitions to be optionally disabled by an environment flag.

Zulip discussion here: [#lean4 > doc-gen4 Equations @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/doc-gen4.20Equations/near/519599099)