### PR TITLE
feat: add option to disable equation generation for definitions via the AnalyzeM monad

### DIFF
--- a/DocGen4/Process/Base.lean
+++ b/DocGen4/Process/Base.lean
@@ -9,6 +9,11 @@ import Lean
 namespace DocGen4.Process
 open Lean Widget Meta
 
+structure DocGenOptions where
+  genEquations : Bool := true
+
+abbrev AnalyzeM : Type → Type := ReaderT DocGenOptions MetaM
+
 /--
 Stores information about a typed name.
 -/

--- a/DocGen4/Process/DocInfo.lean
+++ b/DocGen4/Process/DocInfo.lean
@@ -140,7 +140,8 @@ def isProjFn (declName : Name) : MetaM Bool := do
       || (si.parentInfo.any fun pi => pi.projFn == declName)
   | _ => return false
 
-def ofConstant : (Name × ConstantInfo) → MetaM (Option DocInfo) := fun (name, info) => do
+def ofConstant : (Name × ConstantInfo) → AnalyzeM (Option DocInfo) :=
+  fun (name, info) => do
   if ← isBlackListed name then
     return none
   match info with

--- a/DocGen4/Process/InstanceInfo.lean
+++ b/DocGen4/Process/InstanceInfo.lean
@@ -59,7 +59,7 @@ private def InstanceInfo.ofDefinitionInfo (info : DefinitionInfo) (type : Expr) 
     typeNames,
   }
 
-def InstanceInfo.ofDefinitionVal (v : DefinitionVal) : MetaM InstanceInfo := do
+def InstanceInfo.ofDefinitionVal (v : DefinitionVal) : AnalyzeM InstanceInfo := do
   let info ← DefinitionInfo.ofDefinitionVal v
   InstanceInfo.ofDefinitionInfo info v.type
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ out things that you intend to complete later.
 
 ## Source locations
 
-Source locations default to guessing the Github repo for the library, but different different schemas can be used by setting the `DOCGEN_SRC` environment variable.  For
+Source locations default to guessing the Github repo for the library, but different schemas can be used by setting the `DOCGEN_SRC` environment variable.  For
 example, one can use links that open the local source file in VSCode by running lake with:
 ```
 DOCGEN_SRC="vscode" lake ...
@@ -87,6 +87,9 @@ The different options are:
    This is the default if `DOCGEN_SRC` is unset.
  * `DOCGEN_SRC="file"` creates references to local file references.
  * `DOCGEN_SRC="vscode"` creates [VSCode URLs](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls) to local files.
+
+## Disabling equations
+Generation of equations for definitions is enabled by default, but can be disabled by setting the `DISABLE_EQUATIONS` environment variable to `1`.
 
 ## How does `docs#Nat.add` from the Lean Zulip work?
 If someone sends a message that contains `docs#Nat.add` on the Lean Zulip this will


### PR DESCRIPTION
This PR allows generation of equations for definitions to be optionally disabled by an environment flag.

Zulip discussion here: [#lean4 > doc-gen4 Equations @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/doc-gen4.20Equations/near/519599099)

Supersedes #283. 