### PR TITLE
Fix search results navigation using the arrow keys

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -32,13 +32,16 @@ function handleSearchCursorUpDown(down) {
   const sel = ac_results.querySelector(`.selected`);
   const results = [...ac_results.getElementsByClassName("search_result")];
   const selIndex = results.indexOf(sel);
+  let toSelect;
   if (sel) {
     sel.classList.remove("selected");
-    const toSelect = results[down ? selIndex + 1 : selIndex - 1];
-    toSelect && toSelect.classList.add("selected");
+    toSelect = results[down ? selIndex + 1 : selIndex - 1];
   } else {
-    const toSelect = down ? results[0] : results[results.length-1];
-    toSelect && toSelect.classList.add("selected");
+    toSelect = down ? results[0] : results[results.length-1];
+  }
+  if (toSelect){
+    toSelect.classList.add("selected");
+    toSelect.scrollIntoView({block:"nearest"});
   }
 }
 

--- a/static/search.js
+++ b/static/search.js
@@ -119,8 +119,10 @@ function handleSearch(dataCenter, err, ev, sr, maxResults, autocomplete) {
     for (let i = 0; i < result.length; i += RESULTS_PER_BLOCK) {
       const block = document.createElement("div");
       block.classList.add("search_result_block");
+      const innerBlock = block.appendChild(document.createElement("div"));
+      innerBlock.classList.add("search_result_block_inner");
       for (let j = i; j < Math.min(result.length, i + RESULTS_PER_BLOCK); j++){
-        const row = block.appendChild(document.createElement("div"));
+        const row = innerBlock.appendChild(document.createElement("div"));
         row.classList.add("search_result");
         const linkdiv = row.appendChild(document.createElement("div"))
         linkdiv.classList.add("result_link");

--- a/static/search.js
+++ b/static/search.js
@@ -16,6 +16,10 @@ const SEARCH_RESULTS = document.querySelector("#search_results")
 const AC_MAX_RESULTS = 30
 const SEARCH_PAGE_MAX_RESULTS = undefined
 
+// Search results are sorted into blocks for better performance; this determines the number of search results per block.
+// Must be positive, may be infinite.
+const RESULTS_PER_BLOCK = 20
+
 // Create an `div#autocomplete_results` to hold all autocomplete results.
 let ac_results = document.createElement("div");
 ac_results.id = "autocomplete_results";
@@ -112,15 +116,20 @@ function handleSearch(dataCenter, err, ev, sr, maxResults, autocomplete) {
   
     // update autocomplete results
     removeAllChildren(sr);
-    for (const { name, kind, docLink } of result) {
-      const row = sr.appendChild(document.createElement("div"));
-      row.classList.add("search_result")
-      const linkdiv = row.appendChild(document.createElement("div"))
-      linkdiv.classList.add("result_link")
-      const link = linkdiv.appendChild(document.createElement("a"));
-      link.innerText = name;
-      link.title = name;
-      link.href = SITE_ROOT + docLink;
+    for (let i = 0; i < result.length; i += RESULTS_PER_BLOCK) {
+      const block = document.createElement("div");
+      block.classList.add("search_result_block");
+      for (let j = i; j < Math.min(result.length, i + RESULTS_PER_BLOCK); j++){
+        const row = block.appendChild(document.createElement("div"));
+        row.classList.add("search_result");
+        const linkdiv = row.appendChild(document.createElement("div"))
+        linkdiv.classList.add("result_link");
+        const link = linkdiv.appendChild(document.createElement("a"));
+        link.innerText = result[j].name;
+        link.title = result[j].name;
+        link.href = SITE_ROOT + result[j].docLink;
+      }
+      sr.appendChild(block);
     }
   }
   // handle error

--- a/static/search.js
+++ b/static/search.js
@@ -81,11 +81,15 @@ function removeAllChildren(node) {
   }
 }
 
+// counts how often `handleSearch` has already been called. Used to terminate the previous call whenever a new one has started.
+var handleSearchCounter = 0;
+
 /**
  * Handle user input and perform search.
  */
 async function handleSearch(dataCenter, err, ev, sr, maxResults, autocomplete) {
   const text = ev.target.value;
+  const callIndex = ++handleSearchCounter;
 
   // If no input clear all.
   if (!text) {
@@ -137,9 +141,9 @@ async function handleSearch(dataCenter, err, ev, sr, maxResults, autocomplete) {
         link.href = SITE_ROOT + result[j].docLink;
       }
       sr.appendChild(block);
-      // wait a moment before adding the next block, and only do so if the input hasn't changed since.
+      // wait a moment before adding the next block, and only do so if this method hasn't been called since.
       await new Promise(resolve=>setTimeout(resolve,0));
-      if (ev.target.value != text) return;
+      if (handleSearchCounter!=callIndex) return;
     }
   }
   // handle error

--- a/static/search.js
+++ b/static/search.js
@@ -30,14 +30,14 @@ SEARCH_FORM.appendChild(ac_results);
  */
 function handleSearchCursorUpDown(down) {
   const sel = ac_results.querySelector(`.selected`);
+  const results = [...ac_results.getElementsByClassName("search_result")];
+  const selIndex = results.indexOf(sel);
   if (sel) {
     sel.classList.remove("selected");
-    const toSelect = down
-      ? sel.nextSibling 
-      : sel.previousSibling;
+    const toSelect = results[down ? selIndex + 1 : selIndex - 1];
     toSelect && toSelect.classList.add("selected");
   } else {
-    const toSelect = down ? ac_results.firstChild : ac_results.lastChild;
+    const toSelect = down ? results[0] : results[results.length-1];
     toSelect && toSelect.classList.add("selected");
   }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -329,7 +329,6 @@ header .header_filename {
 
 
 #search_results {
-    display: table;
     width: 100%;
 }
 #search_results[state="done"]:empty::before {
@@ -339,6 +338,11 @@ header .header_filename {
 
 #search_results .result_link, #search_results .result_doc {
     border-bottom: 1px solid rgba(0, 0, 0, 0.8);
+}
+
+.search_result_block {
+    display: table;
+    width: 100%;
 }
 
 .search_result {

--- a/static/style.css
+++ b/static/style.css
@@ -341,6 +341,11 @@ header .header_filename {
 }
 
 .search_result_block {
+    width: 100%;
+    content-visibility: auto;
+}
+
+.search_result_block_inner {
     display: table;
     width: 100%;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -343,6 +343,7 @@ header .header_filename {
 .search_result_block {
     width: 100%;
     content-visibility: auto;
+    contain-intrinsic-size: auto 75em;
 }
 
 .search_result_block_inner {


### PR DESCRIPTION
In #293, I neglected changing the code that allows the user to traverse search results with the up/down arrow keys; as Yael has alerted me, this caused the code to break. This PR contributes a fix, so search results can be navigated with the arrow keys again as before.

I have also included code to automatically scroll the selected search result into view; this seems like reasonable behaviour to me, but apparently was not done before. Let me know if I should move that change into a different PR.