### PR TITLE
Center the current module in expand-nav.js

### DIFF
--- a/static/expand-nav.js
+++ b/static/expand-nav.js
@@ -9,14 +9,16 @@ document.querySelector('.navframe').addEventListener('load', function() {
             var href = a.href.split('#')[0];
             // find the one with the current url
             if (href === currentPageURL) {
-                a.style.fontStyle = 'italic';
+                a.style.fontWeight = 'bold';
+                a.style.color = 'inherit';
                 // open all detail tags above the current
                 var el = a.parentNode.closest('details');
                 while (el) {
                     el.open = true;
                     el = el.parentNode.closest('details');
                 }
-                // seeing as we found the link we were looking for, stop
+                // center the link we were looking for and stop
+                a.scrollIntoView({ behavior: 'instant', block: 'center' });
                 break;
             }
         }


### PR DESCRIPTION
When the page loads, center the scrollbar on the left on the current module:

<img height="400" alt="image" src="https://github.com/user-attachments/assets/6d28ec66-5acd-4c32-b079-af2b0c193ed4" />

This should make it easier to navigate documentation for large projects like mathlib4. 

Also, I made its name slightly more distinguished than just using italic type. 