### PR TITLE
Run expand-nav even if iframe loads before the script

### DIFF
--- a/static/expand-nav.js
+++ b/static/expand-nav.js
@@ -1,4 +1,4 @@
-document.querySelector('.navframe').addEventListener('load', function() {
+function expandNav() {
     // Get the current page URL without the suffix after #
     var currentPageURL = window.location.href.split('#')[0];
 
@@ -23,4 +23,11 @@ document.querySelector('.navframe').addEventListener('load', function() {
             }
         }
     }
-});
+}
+
+var navFrame = document.querySelector('.navframe');
+if (navFrame.contentDocument.readyState === "complete") {
+    expandNav();
+} else {
+    navFrame.addEventListener('load', expandNav);
+}


### PR DESCRIPTION
It looks like my #311 doesn't quite always trigger. I think it's because the iframe and the script are loaded in parallel and so we may or may not see a `load` event after the time the script runs.

This patch seems to fix the issue (tested on [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs) with Firefox's script override).