### PR TITLE
replace deprecated ToText instance with QueryText

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -217,7 +217,7 @@ def mk (direct : Array α) (trans : Array (DepSet α)) : DepSet α := Id.run do
 def toArray (d : DepSet α) : Array α := d.1 ++ d.2.toArray
 
 instance [Lean.ToJson α] : Lean.ToJson (OrdHashSet α) where toJson x := Lean.toJson x.toArray
-instance [ToText α] : Lake.ToText (DepSet α) where toText d := Lake.ToText.toText d.toArray
+instance [QueryText α] : Lake.QueryText (DepSet α) where queryText d := Lake.QueryText.queryText d.toArray
 
 end DepSet
 


### PR DESCRIPTION
Currently when I do `lake build` on this project, I see:

```shell
warning: /home/dwrensha/src/doc-gen4/lakefile.lean:220:10: `Lake.ToText` has been deprecated: Use `Lake.QueryText` instead
warning: /home/dwrensha/src/doc-gen4/lakefile.lean:220:22: `Lake.ToText` has been deprecated: Use `Lake.QueryText` instead
```

The deprecation was made in https://github.com/leanprover/lean4/pull/9698.

This PR makes the suggested updates and thereby eliminates the warnings.