### PR TITLE
highlight direct use of sorry

### DIFF
--- a/DocGen4/Output/Module.lean
+++ b/DocGen4/Output/Module.lean
@@ -90,8 +90,9 @@ def docInfoToHtml (module : Name) (doc : DocInfo) : HtmlM Html := do
       #[Html.element "div" false #[("class", "attributes")] #[attrStr]]
     else
       #[]
+  let cssClass := "decl" ++ if doc.getSorried then " sorried" else ""
   pure
-    <div class="decl" id={doc.getName.toString}>
+    <div class={cssClass} id={doc.getName.toString}>
       <div class={doc.getKind}>
         <div class="gh_link">
           <a href={← getSourceUrl module doc.getDeclarationRange}>source</a>

--- a/DocGen4/Output/Module.lean
+++ b/DocGen4/Output/Module.lean
@@ -43,10 +43,11 @@ and name.
 def docInfoHeader (doc : DocInfo) : HtmlM Html := do
   let mut nodes := #[]
   nodes := nodes.push <| Html.element "span" false #[("class", "decl_kind")] #[doc.getKindDescription]
-  nodes := nodes.push
-    <span class="decl_name">
-      {← declNameToHtmlBreakWithinLink doc.getName}
-    </span>
+  -- TODO: Can we inline if-then-else and avoid repeating <span> here?
+  if doc.getSorried then
+    nodes := nodes.push <span class="decl_name" title="declaration uses 'sorry'"> {← declNameToHtmlBreakWithinLink doc.getName} </span>
+  else
+    nodes := nodes.push <span class="decl_name"> {← declNameToHtmlBreakWithinLink doc.getName} </span>
   for arg in doc.getArgs do
     nodes := nodes.push (← argToHtml arg)
 

--- a/DocGen4/Process/Base.lean
+++ b/DocGen4/Process/Base.lean
@@ -62,6 +62,10 @@ structure Info extends NameInfo where
   -/
   attrs : Array String
   /--
+  Whether this item depends on `sorryAx`.
+  -/
+  sorried : Bool := true
+  /--
   Whether this info item should be rendered
   -/
   render : Bool := true

--- a/DocGen4/Process/Base.lean
+++ b/DocGen4/Process/Base.lean
@@ -62,9 +62,9 @@ structure Info extends NameInfo where
   -/
   attrs : Array String
   /--
-  Whether this item depends on `sorryAx`.
+  Whether this declaration directly uses `sorryAx`.
   -/
-  sorried : Bool := true
+  sorried : Bool := false
   /--
   Whether this info item should be rendered
   -/

--- a/DocGen4/Process/DefinitionInfo.lean
+++ b/DocGen4/Process/DefinitionInfo.lean
@@ -42,6 +42,7 @@ def DefinitionInfo.ofDefinitionVal (v : DefinitionVal) : AnalyzeM DefinitionInfo
   let info ← Info.ofConstantVal v.toConstantVal
   let isUnsafe := v.safety == DefinitionSafety.unsafe
   let isNonComputable := isNoncomputable (← getEnv) v.name
+  let sorried := v.value.hasSorry
 
   let equations ←
     tryCatchRuntimeEx
@@ -51,7 +52,7 @@ def DefinitionInfo.ofDefinitionVal (v : DefinitionVal) : AnalyzeM DefinitionInfo
         return none)
 
   return {
-    toInfo := info,
+    toInfo := { info with sorried := sorried },
     isUnsafe,
     hints := v.hints,
     equations,

--- a/DocGen4/Process/DocInfo.lean
+++ b/DocGen4/Process/DocInfo.lean
@@ -81,6 +81,18 @@ def getArgs : DocInfo → Array Arg
 | classInductiveInfo i => i.args
 | ctorInfo i => i.args
 
+def getSorried : DocInfo → Bool
+| axiomInfo i => i.sorried
+| theoremInfo i => i.sorried
+| opaqueInfo i => i.sorried
+| definitionInfo i => i.sorried
+| instanceInfo i => i.sorried
+| inductiveInfo i => i.sorried
+| structureInfo i => i.sorried
+| classInfo i => i.sorried
+| classInductiveInfo i => i.sorried
+| ctorInfo i => i.sorried
+
 def getAttrs : DocInfo → Array String
 | axiomInfo i => i.attrs
 | theoremInfo i => i.attrs

--- a/DocGen4/Process/NameInfo.lean
+++ b/DocGen4/Process/NameInfo.lean
@@ -62,6 +62,7 @@ def Info.ofTypedName (n : Name) (t : Expr) : MetaM Info := do
     let fmt ← prettyPrintBinder binder infos
     return Arg.mk fmt (!binder.isOfKind ``Parser.Term.explicitBinder)
   let type ← prettyPrintTermStx type infos
+  let axioms ← collectAxioms n
   match ← findDeclarationRanges? n with
   -- TODO: Maybe selection range is more relevant? Figure this out in the future
   | some range =>
@@ -69,6 +70,7 @@ def Info.ofTypedName (n : Name) (t : Expr) : MetaM Info := do
       toNameInfo := { name := n, type, doc := ← findDocString? (← getEnv) n},
       args,
       declarationRange := range.range,
+      sorried := axioms.contains ``sorryAx,
       attrs := ← getAllAttributes n
     }
   | none => panic! s!"{n} is a declaration without position"

--- a/DocGen4/Process/NameInfo.lean
+++ b/DocGen4/Process/NameInfo.lean
@@ -62,7 +62,6 @@ def Info.ofTypedName (n : Name) (t : Expr) : MetaM Info := do
     let fmt ← prettyPrintBinder binder infos
     return Arg.mk fmt (!binder.isOfKind ``Parser.Term.explicitBinder)
   let type ← prettyPrintTermStx type infos
-  let axioms ← collectAxioms n
   match ← findDeclarationRanges? n with
   -- TODO: Maybe selection range is more relevant? Figure this out in the future
   | some range =>
@@ -70,7 +69,6 @@ def Info.ofTypedName (n : Name) (t : Expr) : MetaM Info := do
       toNameInfo := { name := n, type, doc := ← findDocString? (← getEnv) n},
       args,
       declarationRange := range.range,
-      sorried := axioms.contains ``sorryAx,
       attrs := ← getAllAttributes n
     }
   | none => panic! s!"{n} is a declaration without position"
@@ -78,5 +76,4 @@ def Info.ofTypedName (n : Name) (t : Expr) : MetaM Info := do
 def Info.ofConstantVal (v : ConstantVal) : MetaM Info := do
   let e := Expr.const v.name (v.levelParams.map mkLevelParam)
   ofTypedName v.name (← inferType e)
-
 end DocGen4.Process

--- a/DocGen4/Process/TheoremInfo.lean
+++ b/DocGen4/Process/TheoremInfo.lean
@@ -14,6 +14,7 @@ open Lean Meta
 
 def TheoremInfo.ofTheoremVal (v : TheoremVal) : MetaM TheoremInfo := do
   let info ← Info.ofConstantVal v.toConstantVal
-  return { toInfo := info }
+  -- We mark direct uses of sorry:
+  return { toInfo := { info with sorried := v.value.hasSorry } }
 
 end DocGen4.Process

--- a/static/style.css
+++ b/static/style.css
@@ -679,16 +679,8 @@ main h2, main h3, main h4, main h5, main h6 {
     margin-left: 4ex; /* extra indentation */
 }
 
-.decl.sorried {
-    background-color: #fff0f0;
-}
-
-.decl .sorry_msg {
-    background-color: #ffdada;
-    /* this pushes it flush with the colored margin */
-    margin-left: -8px;
-    margin-right: -8px;
-    padding: 8px;
+.decl.sorried .decl_name {
+    text-decoration: underline wavy #cca733;
 }
 
 .decl .sorry_msg > strong {

--- a/static/style.css
+++ b/static/style.css
@@ -679,6 +679,22 @@ main h2, main h3, main h4, main h5, main h6 {
     margin-left: 4ex; /* extra indentation */
 }
 
+.decl.sorried {
+    background-color: #fff0f0;
+}
+
+.decl .sorry_msg {
+    background-color: #ffdada;
+    /* this pushes it flush with the colored margin */
+    margin-left: -8px;
+    margin-right: -8px;
+    padding: 8px;
+}
+
+.decl .sorry_msg > strong {
+    color: #a90000;
+}
+
 .imports li, code, .decl_header, .attributes, .structure_field_info,
         .constructor, .instances li, .instances-for-list li, .equation, .structure_ext_ctor {
     font-size: 92%;


### PR DESCRIPTION
This is work in progress to add one of the two features discussed in #270, namely to highlight direct uses of sorry.

Transitive/implicit depending on `sorryAx` is not done, my naive approach for doing that was way to recursive and slowing things down too much, as [discussed on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/can.20doc-gen4.20show.20sorry-dependency.3F/near/541916787).

An example for what the result looks like can be seen at https://m4lvin.github.io/lean4-pdl/docs/Pdl/PartInterpolation.html#Cluster-tools