### PR TITLE
docs: Fix the broken link to TPiL

### DIFF
--- a/DocGen4/Output/FoundationalTypes.lean
+++ b/DocGen4/Output/FoundationalTypes.lean
@@ -13,7 +13,7 @@ def foundationalTypes : BaseHtmlM Html := templateLiftExtends (baseHtml "Foundat
 
       <p>Some of Lean's types are not defined in any Lean source files (even the <code>prelude</code>) since they come from its foundational type theory. This page provides basic documentation for these types.</p>
       <p>For a more in-depth explanation of Lean's type theory, refer to
-      <a href="https://leanprover.github.io/theorem_proving_in_lean4/dependent_type_theory.html">TPiL</a>.</p>
+      <a href="https://leanprover.github.io/theorem_proving_in_lean4/Dependent-Type-Theory/">TPiL</a>.</p>
 
 
       <h2 id="codesort-ucode"><code>Sort u</code></h2>


### PR DESCRIPTION
You can go to [Foundational Types in mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/foundational_types.html) and click the link to TPiL.

- Before: https://leanprover.github.io/theorem_proving_in_lean4/dependent_type_theory.html
- After: https://leanprover.github.io/theorem_proving_in_lean4/Dependent-Type-Theory/