### PR TITLE
Add custom source linker support for HTML output

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -88,14 +88,14 @@ def htmlOutputDeclarationDatas (buildDir : System.FilePath) (result : AnalyzerRe
     let jsonDecls ← Module.toJson mod
     FS.writeFile (declarationsBasePath buildDir / s!"declaration-data-{mod.name}.bmp") (toJson jsonDecls).compress
 
-/-- Custom source linker type: given a module name, returns a function from declaration range to URL -/
-abbrev SourceLinkerFn := Name → Option DeclarationRange → String
+/-- Custom source linker type: given an optional source URL and module name, returns a function from declaration range to URL -/
+abbrev SourceLinkerFn := Option String → Name → Option DeclarationRange → String
 
 def htmlOutputResults (baseConfig : SiteBaseContext) (result : AnalyzerResult) (sourceUrl? : Option String)
     (sourceLinker? : Option SourceLinkerFn := none) : IO (Array System.FilePath) := do
   let config : SiteContext := {
     result := result
-    sourceLinker := sourceLinker?.getD (SourceLinker.sourceLinker sourceUrl?)
+    sourceLinker := (sourceLinker?.getD SourceLinker.sourceLinker) sourceUrl?
     refsMap := .ofList (baseConfig.refs.map fun x => (x.citekey, x)).toList
   }
 


### PR DESCRIPTION
This PR introduces an optional SourceLinkerFn parameter to htmlOutputResults and htmlOutput, enabling custom source linking logic instead of relying solely on the default URL-based linker.

Motivation

The current doc-gen4 implementation computes source links internally using a fixed algorithm based on sourceUrl?. While this works well for standard GitHub repositories, some use cases require more sophisticated source linking:

- Multi-repository documentation - Projects that aggregate documentation from multiple repositories need different base URLs for different modules
- Custom hosting platforms - Source code hosted on platforms with non-standard URL patterns
- Monorepo support - Projects where different modules map to different subdirectories
- Integration with other tools - I'm developing a doc-gen4 "plugin" that combines doc-gen4 with additional documentation where I need to customize source URL generation.


New type alias:

```lean
abbrev SourceLinkerFn := Option String → Name → Option DeclarationRange → String
```

Updated signatures:

```lean
def htmlOutputResults (baseConfig : SiteBaseContext) (result : AnalyzerResult) 
    (sourceUrl? : Option String) (sourceLinker? : Option SourceLinkerFn := none) : IO (Array System.FilePath)

def htmlOutput (buildDir : System.FilePath) (result : AnalyzerResult) (hierarchy : Hierarchy)
    (sourceUrl? : Option String) (sourceLinker? : Option SourceLinkerFn := none) : IO Unit
```

Backward Compatibility
- The new `sourceLinker?` parameter defaults to `none`, preserving existing behavior
- When `sourceLinker?` is none, the existing `SourceLinker.sourceLinker` is used
- All existing code calling these functions without the new parameter continues to work unchanged

Example usage:

```lean
-- Custom source linker that handles multiple repositories
def mySourceLinker : SourceLinkerFn := fun _sourceUrl? module range =>
  let root := module.getRoot
  let baseUrl := if root == `MyLib then "https://github.com/org/mylib" 
                 else "https://github.com/org/other"
  -- ... compute URL with line range
  s!"{baseUrl}/blob/main/{path}#L{startLine}-L{endLine}"

-- Use custom linker
DocGen4.htmlOutputResults baseConfig result none (some mySourceLinker)
```
