### PR TITLE
feat: add declarationDecorator hook for external tools

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -92,11 +92,13 @@ def htmlOutputDeclarationDatas (buildDir : System.FilePath) (result : AnalyzerRe
 abbrev SourceLinkerFn := Option String → Name → Option DeclarationRange → String
 
 def htmlOutputResults (baseConfig : SiteBaseContext) (result : AnalyzerResult) (sourceUrl? : Option String)
-    (sourceLinker? : Option SourceLinkerFn := none) : IO (Array System.FilePath) := do
+    (sourceLinker? : Option SourceLinkerFn := none)
+    (declarationDecorator? : Option DeclarationDecoratorFn := none) : IO (Array System.FilePath) := do
   let config : SiteContext := {
     result := result
     sourceLinker := (sourceLinker?.getD SourceLinker.sourceLinker) sourceUrl?
     refsMap := .ofList (baseConfig.refs.map fun x => (x.citekey, x)).toList
+    declarationDecorator := declarationDecorator?.getD defaultDeclarationDecorator
   }
 
   FS.createDirAll <| basePath baseConfig.buildDir
@@ -186,9 +188,10 @@ The main entrypoint for outputting the documentation HTML based on an
 `AnalyzerResult`.
 -/
 def htmlOutput (buildDir : System.FilePath) (result : AnalyzerResult) (hierarchy : Hierarchy)
-    (sourceUrl? : Option String) (sourceLinker? : Option SourceLinkerFn := none) : IO Unit := do
+    (sourceUrl? : Option String) (sourceLinker? : Option SourceLinkerFn := none)
+    (declarationDecorator? : Option DeclarationDecoratorFn := none) : IO Unit := do
   let baseConfig ← getSimpleBaseContext buildDir hierarchy
-  discard <| htmlOutputResults baseConfig result sourceUrl? sourceLinker?
+  discard <| htmlOutputResults baseConfig result sourceUrl? sourceLinker? declarationDecorator?
   htmlOutputIndex baseConfig
 
 end DocGen4

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -71,6 +71,18 @@ structure SiteBaseContext where
   refs : Array BibItem
 
 /--
+Declaration decorator function type: given a module name, declaration name, and declaration kind,
+returns optional extra HTML to inject into the declaration's rendering.
+This enables external tools to add badges, links, or other decorations to declarations.
+-/
+abbrev DeclarationDecoratorFn := Name → Name → String → Array Html
+
+/--
+The default declaration decorator that produces no extra HTML.
+-/
+def defaultDeclarationDecorator : DeclarationDecoratorFn := fun _ _ _ => #[]
+
+/--
 The read-only context used in the `HtmlM` monad for HTML templating.
 -/
 structure SiteContext where
@@ -86,6 +98,12 @@ structure SiteContext where
   The references as a map.
   -/
   refsMap : Std.HashMap String BibItem
+  /--
+  A function to decorate declarations with extra HTML (e.g., verification badges).
+  Receives (moduleName, declarationName, declarationKind) and returns extra HTML.
+  Defaults to producing no extra HTML.
+  -/
+  declarationDecorator : DeclarationDecoratorFn := defaultDeclarationDecorator
 
 /--
 The writable state used in the `HtmlM` monad for HTML templating.
@@ -151,6 +169,7 @@ def getHierarchy : BaseHtmlM Hierarchy := do return (← read).hierarchy
 def getCurrentName : BaseHtmlM (Option Name) := do return (← read).currentName
 def getResult : HtmlM AnalyzerResult := do return (← read).result
 def getSourceUrl (module : Name) (range : Option DeclarationRange): HtmlM String := do return (← read).sourceLinker module range
+def getDeclarationDecorator : HtmlM DeclarationDecoratorFn := do return (← read).declarationDecorator
 
 /--
 If a template is meant to be extended because it for example only provides the

--- a/DocGen4/Output/Module.lean
+++ b/DocGen4/Output/Module.lean
@@ -91,6 +91,9 @@ def docInfoToHtml (module : Name) (doc : DocInfo) : HtmlM Html := do
       #[Html.element "div" false #[("class", "attributes")] #[attrStr]]
     else
       #[]
+  -- custom decoration (e.g., verification badges from external tools)
+  let decorator ← getDeclarationDecorator
+  let decoratorHtml := decorator module doc.getName doc.getKind
   let cssClass := "decl" ++ if doc.getSorried then " sorried" else ""
   pure
     <div class={cssClass} id={doc.getName.toString}>
@@ -98,6 +101,7 @@ def docInfoToHtml (module : Name) (doc : DocInfo) : HtmlM Html := do
         <div class="gh_link">
           <a href={← getSourceUrl module doc.getDeclarationRange}>source</a>
         </div>
+        [decoratorHtml]
         [attrsHtml]
         {← docInfoHeader doc}
         [docStringHtml]


### PR DESCRIPTION
Add an optional declarationDecorator parameter to htmlOutputResults and htmlOutput that allows external tools to inject custom HTML into each declaration's rendering.

This follows the same pattern as the existing sourceLinker customization, enabling tools like doc-verification-bridge to add verification badges, coverage links, or other decorations to declarations without modifying doc-gen4 internals.

The decorator function receives (moduleName, declarationName, declarationKind) and returns an Array Html that is rendered after the source link.

Closes https://github.com/leanprover/doc-gen4/issues/343