### PR TITLE
feat: allow linking to tactics with user-facing names

### DIFF
--- a/DocGen4/Output/Tactics.lean
+++ b/DocGen4/Output/Tactics.lean
@@ -30,8 +30,8 @@ def TacticInfo.toHtml (tac : TacticInfo Html) : Output.BaseHtmlM Html := do
   let userNameAnchor := "userName-" ++ tac.userName
   let defLink := (← moduleNameToLink tac.definingModule) ++ "#" ++ internalName
   let tags := ", ".intercalate (tac.tags.map (·.toString)).qsort.toList
-  return <div id={internalName}>
-    <h2 id={userNameAnchor}>{tac.userName}</h2>
+  return <div id={internalName}> <div id={userNameAnchor}>
+    <h2>{tac.userName}</h2>
     {tac.docString}
     <dl>
       <dt>Tags:</dt>
@@ -39,7 +39,7 @@ def TacticInfo.toHtml (tac : TacticInfo Html) : Output.BaseHtmlM Html := do
       <dt>Defined in module:</dt>
       <dd><a href={defLink}>{tac.definingModule.toString}</a></dd>
     </dl>
-  </div>
+  </div> </div>
 
 def TacticInfo.navLink (tac : TacticInfo α) : Html :=
   <p><a href={"#".append tac.internalName.toString}>{tac.userName}</a></p>

--- a/DocGen4/Output/Tactics.lean
+++ b/DocGen4/Output/Tactics.lean
@@ -24,11 +24,14 @@ def TacticInfo.docStringToHtml (tac : TacticInfo MarkdownDocstring) : Output.Htm
 Render the HTML for a single tactic.
 -/
 def TacticInfo.toHtml (tac : TacticInfo Html) : Output.BaseHtmlM Html := do
+  -- Used by the side bar to link to particular declarations, should be globally unique.
   let internalName := tac.internalName.toString
+  -- Can be used by external links (e.g. Zulip linkifiers), not guaranteed to be unique.
+  let userNameAnchor := "userName-" ++ tac.userName
   let defLink := (← moduleNameToLink tac.definingModule) ++ "#" ++ internalName
   let tags := ", ".intercalate (tac.tags.map (·.toString)).qsort.toList
   return <div id={internalName}>
-    <h2>{tac.userName}</h2>
+    <h2 id={userNameAnchor}>{tac.userName}</h2>
     {tac.docString}
     <dl>
       <dt>Tags:</dt>


### PR DESCRIPTION
This PR adds an `id` attribute based on the `userName` attribute of a tactic to the doc-gen tactic overview page, so we can offer predictable links of the form `docs/tactics.html#userName-apply` for the `apply` tactic. For example, we can use that in the Zulip linkifier.

Some considerations for reviewers:
* tactic `userName`s are not guaranteed to be unique, so the `internalName` should still be used for machine-generated links. We end up with non-unique `id` attribute values, but browsers tend to handle this gracefully enough.
* adding this `userName-` prefix makes the URLs more ugly, but it prevents name collisions. We could also consider instead leaving the `userName` unprefixed, even if it breaks old links.
* I put the `id` attribute on the first element inside the `div`, since duplicate `id` attributes on the same element are not allowed. Not sure if this is the best practice: maybe instead nest two divs inside of each other?