### PR TITLE
feat: interproject linking — document a project without its dependencies

### DIFF
--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -184,12 +184,30 @@ def getSimpleBaseContext (buildDir : System.FilePath) (hierarchy : Hierarchy) :
     | .error err =>
       throw <| IO.userError s!"Failed to parse 'references.json': {err}"
     | .ok (refs : Array BibItem) =>
+      -- Optional interproject linking: a documentation site for this project's dependencies
+      -- (e.g. Mathlib) plus the set of module namespaces that are local to this project. When
+      -- both are set, modules outside `localModuleRoots` are treated as external — their pages
+      -- are not generated and references to them link to `depsDocsUrl?`. See
+      -- `SiteBaseContext.depsDocsUrl?`, `SiteBaseContext.localModuleRoots`, and `moduleIsExternal`.
+      let depsDocsUrl? ← do
+        match ← IO.getEnv "DOCGEN_DEPS_DOCS_URL" with
+        | some url =>
+          let u := url.trimAscii.copy
+          if u.isEmpty then pure none else pure (some u)
+        | none => pure none
+      let localModuleRoots ← do
+        match ← IO.getEnv "DOCGEN_LOCAL_MODULE_ROOTS" with
+        | some s =>
+          pure <| s.splitOn "," |>.map (·.trimAscii.copy) |>.filter (! ·.isEmpty) |>.map String.toName |>.toArray
+        | none => pure #[]
       return {
         buildDir := buildDir
         depthToRoot := 0
         currentName := none
         hierarchy := hierarchy
         refs := refs
+        depsDocsUrl?
+        localModuleRoots
       }
 
 def htmlOutputIndex (baseConfig : SiteBaseContext) (modules : Array JsonModule) (tacticInfo : Array (Process.TacticInfo Html)) : IO Unit := do

--- a/DocGen4/Output.lean
+++ b/DocGen4/Output.lean
@@ -184,17 +184,39 @@ def getSimpleBaseContext (buildDir : System.FilePath) (hierarchy : Hierarchy) :
     | .error err =>
       throw <| IO.userError s!"Failed to parse 'references.json': {err}"
     | .ok (refs : Array BibItem) =>
-      -- Optional interproject linking: a documentation site for this project's dependencies
-      -- (e.g. Mathlib) plus the set of module namespaces that are local to this project. When
-      -- both are set, modules outside `localModuleRoots` are treated as external — their pages
-      -- are not generated and references to them link to `depsDocsUrl?`. See
-      -- `SiteBaseContext.depsDocsUrl?`, `SiteBaseContext.localModuleRoots`, and `moduleIsExternal`.
+      -- Optional interproject linking: documentation sites for this project's dependencies plus
+      -- the set of module namespaces that are local to this project. Modules outside
+      -- `localModuleRoots` are treated as external — their pages are not generated and references
+      -- to them use a per-root URL from `depsDocsUrls`, falling back to `depsDocsUrl?`.
       let depsDocsUrl? ← do
         match ← IO.getEnv "DOCGEN_DEPS_DOCS_URL" with
         | some url =>
           let u := url.trimAscii.copy
           if u.isEmpty then pure none else pure (some u)
         | none => pure none
+      let depsDocsUrls ← do
+        match ← IO.getEnv "DOCGEN_DEPS_DOCS_URLS" with
+        | none => pure #[]
+        | some value =>
+          let mut mappings : Array (Name × String) := #[]
+          for rawEntry in value.splitOn "," do
+            let entry := rawEntry.trimAscii.copy
+            if entry.isEmpty then continue
+            match entry.splitOn "=" with
+            | rootString :: urlParts =>
+              let rootString := rootString.trimAscii.copy
+              let url := "=".intercalate urlParts |>.trimAscii.copy
+              let root := rootString.toName
+              if rootString.isEmpty || root.isAnonymous || root != root.getRoot then
+                throw <| IO.userError s!"Invalid module root '{rootString}' in DOCGEN_DEPS_DOCS_URLS"
+              if url.isEmpty then
+                throw <| IO.userError s!"Missing documentation URL for module root '{rootString}' in DOCGEN_DEPS_DOCS_URLS"
+              if mappings.any (fun (existingRoot, _) => existingRoot == root) then
+                throw <| IO.userError s!"Duplicate module root '{rootString}' in DOCGEN_DEPS_DOCS_URLS"
+              mappings := mappings.push (root, url)
+            | [] =>
+              throw <| IO.userError s!"Invalid entry '{entry}' in DOCGEN_DEPS_DOCS_URLS; expected ROOT=URL"
+          pure mappings
       let localModuleRoots ← do
         match ← IO.getEnv "DOCGEN_LOCAL_MODULE_ROOTS" with
         | some s =>
@@ -207,6 +229,7 @@ def getSimpleBaseContext (buildDir : System.FilePath) (hierarchy : Hierarchy) :
         hierarchy := hierarchy
         refs := refs
         depsDocsUrl?
+        depsDocsUrls
         localModuleRoots
       }
 

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -70,6 +70,23 @@ structure SiteBaseContext where
   The list of references, as an array.
   -/
   refs : Array BibItem
+  /--
+  Base URL of a documentation site for this project's dependencies, e.g. Mathlib's
+  `https://leanprover-community.github.io/mathlib4_docs`. Set via the `DOCGEN_DEPS_DOCS_URL`
+  environment variable. When set together with `localModuleRoots`, references to declarations
+  that live in *external* modules (see `localModuleRoots`) are linked into that site's `/find`
+  resolver — which looks a declaration up by name, tolerating version skew — instead of being
+  linked locally. `none` reproduces the previous behaviour.
+  -/
+  depsDocsUrl? : Option String := none
+  /--
+  The top-level module namespaces that belong to *this* project, e.g. `#[`TauCeti]`. Set via
+  the `DOCGEN_LOCAL_MODULE_ROOTS` environment variable (comma-separated). A module is
+  "external" when this array is non-empty and the module's root is not one of these — its pages
+  are not generated and references to it link to `depsDocsUrl?`. Empty (the default) means
+  every module is local, reproducing the previous behaviour.
+  -/
+  localModuleRoots : Array Name := #[]
 
 /--
 Declaration decorator function type: given a module name, declaration name, and declaration kind,
@@ -183,11 +200,46 @@ def templateExtends {α β} {m} [Bind m] (base : α → m β) (new : m α) : m �
 def templateLiftExtends {α β} {m n} [Bind m] [MonadLiftT n m] (base : α → n β) (new : m α) : m β :=
   new >>= (monadLift ∘ base)
 /--
-Returns the doc-gen4 link to a module name.
+The base URL of the dependency documentation site, with any trailing slash removed, or `none`
+when interproject linking is not configured.
 -/
-def moduleNameToLink (n : Name) : BaseHtmlM String := do
+def depsDocsBaseUrl? : BaseHtmlM (Option String) := do
+  match (← read).depsDocsUrl? with
+  | some url => return some (if url.endsWith "/" then (url.dropEnd 1).copy else url)
+  | none => return none
+
+/--
+Whether `mod` belongs to an external dependency rather than to this project, and therefore
+should be linked to `depsDocsUrl?` instead of documented locally. A module is external only
+when `localModuleRoots` is non-empty (interproject linking enabled) and the module's root
+namespace is not among them.
+-/
+def moduleIsExternal (mod : Name) : BaseHtmlM Bool := do
+  let roots := (← read).localModuleRoots
+  if roots.isEmpty then
+    return false
+  else
+    return !roots.contains mod.getRoot
+
+/-- The relative on-site path for a module, e.g. `../Foo/Bar.html`. -/
+def moduleOnSitePath (n : Name) : BaseHtmlM String := do
   let parts := n.components.map (Name.toString (escape := False))
   return (← getRoot) ++ (parts.intersperse "/").foldl (· ++ ·) "" ++ ".html"
+
+/--
+Returns the doc-gen4 link to a module name. For a module belonging to an external dependency
+(see `moduleIsExternal`), this points at the configured dependency documentation site; for a
+local module it is a relative on-site link, as before.
+-/
+def moduleNameToLink (n : Name) : BaseHtmlM String := do
+  match ← depsDocsBaseUrl? with
+  | some base =>
+    if ← moduleIsExternal n then
+      let parts := n.components.map (Name.toString (escape := False))
+      return base ++ "/" ++ (parts.intersperse "/").foldl (· ++ ·) "" ++ ".html"
+    else
+      moduleOnSitePath n
+  | none => moduleOnSitePath n
 
 /--
 Returns the HTML doc-gen4 link to a module name.
@@ -226,11 +278,18 @@ are used in documentation generation, notably JS and CSS ones.
 end Static
 
 /--
-Returns the doc-gen4 link to a declaration name.
+Returns the doc-gen4 link to a declaration name. When the declaration lives in an external
+dependency module (see `moduleIsExternal`), the link goes to the dependency documentation
+site's `/find` resolver, which looks the declaration up by name — this is robust to the
+dependency's docs being built from a slightly different revision than the one linked against.
+Otherwise it is a local relative link, as before.
 -/
 def declNameToLink (name : Name) : HtmlM String := do
   let res ← getResult
   let module := res.moduleNames[res.name2ModIdx[name]!.toNat]!
+  if let some base ← depsDocsBaseUrl? then
+    if ← moduleIsExternal module then
+      return base ++ "/find/?pattern=" ++ name.toString ++ "#doc"
   return (← moduleNameToLink module) ++ "#" ++ name.toString
 
 /--

--- a/DocGen4/Output/Base.lean
+++ b/DocGen4/Output/Base.lean
@@ -71,20 +71,25 @@ structure SiteBaseContext where
   -/
   refs : Array BibItem
   /--
-  Base URL of a documentation site for this project's dependencies, e.g. Mathlib's
+  Fallback base URL of a documentation site for this project's dependencies, e.g. Mathlib's
   `https://leanprover-community.github.io/mathlib4_docs`. Set via the `DOCGEN_DEPS_DOCS_URL`
-  environment variable. When set together with `localModuleRoots`, references to declarations
-  that live in *external* modules (see `localModuleRoots`) are linked into that site's `/find`
-  resolver — which looks a declaration up by name, tolerating version skew — instead of being
-  linked locally. `none` reproduces the previous behaviour.
+  environment variable. Per-module-root overrides can be supplied in `depsDocsUrls`.
   -/
   depsDocsUrl? : Option String := none
+  /--
+  Per-module-root dependency documentation URLs, set via the `DOCGEN_DEPS_DOCS_URLS`
+  environment variable. For example, `#[(`Mathlib, "https://..."), (`Batteries, "https://...")]`
+  sends references into each dependency's own documentation site. These mappings take precedence
+  over `depsDocsUrl?`.
+  -/
+  depsDocsUrls : Array (Name × String) := #[]
   /--
   The top-level module namespaces that belong to *this* project, e.g. `#[`TauCeti]`. Set via
   the `DOCGEN_LOCAL_MODULE_ROOTS` environment variable (comma-separated). A module is
   "external" when this array is non-empty and the module's root is not one of these — its pages
-  are not generated and references to it link to `depsDocsUrl?`. Empty (the default) means
-  every module is local, reproducing the previous behaviour.
+  are not generated and references to it link to the matching entry in `depsDocsUrls`, or to
+  `depsDocsUrl?` as a fallback. Empty (the default) means every module is local, reproducing the
+  previous behaviour.
   -/
   localModuleRoots : Array Name := #[]
 
@@ -199,12 +204,18 @@ def templateExtends {α β} {m} [Bind m] (base : α → m β) (new : m α) : m �
 
 def templateLiftExtends {α β} {m n} [Bind m] [MonadLiftT n m] (base : α → n β) (new : m α) : m β :=
   new >>= (monadLift ∘ base)
+/-- The configured documentation URL for `mod`, before URL normalization. -/
+def SiteBaseContext.depsDocsUrlFor? (ctx : SiteBaseContext) (mod : Name) : Option String :=
+  match ctx.depsDocsUrls.find? (fun (root, _) => root == mod.getRoot) with
+  | some (_, url) => some url
+  | none => ctx.depsDocsUrl?
+
 /--
-The base URL of the dependency documentation site, with any trailing slash removed, or `none`
-when interproject linking is not configured.
+The base URL of the dependency documentation site for `mod`, with a trailing slash removed, or
+`none` when no per-root mapping or fallback URL is configured.
 -/
-def depsDocsBaseUrl? : BaseHtmlM (Option String) := do
-  match (← read).depsDocsUrl? with
+def depsDocsBaseUrl? (mod : Name) : BaseHtmlM (Option String) := do
+  match (← read).depsDocsUrlFor? mod with
   | some url => return some (if url.endsWith "/" then (url.dropEnd 1).copy else url)
   | none => return none
 
@@ -232,14 +243,14 @@ Returns the doc-gen4 link to a module name. For a module belonging to an externa
 local module it is a relative on-site link, as before.
 -/
 def moduleNameToLink (n : Name) : BaseHtmlM String := do
-  match ← depsDocsBaseUrl? with
-  | some base =>
-    if ← moduleIsExternal n then
+  if ← moduleIsExternal n then
+    match ← depsDocsBaseUrl? n with
+    | some base =>
       let parts := n.components.map (Name.toString (escape := False))
       return base ++ "/" ++ (parts.intersperse "/").foldl (· ++ ·) "" ++ ".html"
-    else
-      moduleOnSitePath n
-  | none => moduleOnSitePath n
+    | none => moduleOnSitePath n
+  else
+    moduleOnSitePath n
 
 /--
 Returns the HTML doc-gen4 link to a module name.
@@ -287,8 +298,8 @@ Otherwise it is a local relative link, as before.
 def declNameToLink (name : Name) : HtmlM String := do
   let res ← getResult
   let module := res.moduleNames[res.name2ModIdx[name]!.toNat]!
-  if let some base ← depsDocsBaseUrl? then
-    if ← moduleIsExternal module then
+  if ← moduleIsExternal module then
+    if let some base ← depsDocsBaseUrl? module then
       return base ++ "/find/?pattern=" ++ name.toString ++ "#doc"
   return (← moduleNameToLink module) ++ "#" ++ name.toString
 

--- a/Main.lean
+++ b/Main.lean
@@ -89,13 +89,22 @@ def runFromDbCmd (p : Parsed) : IO UInt32 := do
   let linkCtx ← db.loadLinkingContext
 
   -- Determine which modules to generate HTML for
-  let targetModules ←
+  let targetModulesAll ←
     if moduleRoots.isEmpty then
       pure linkCtx.moduleNames
     else
       db.getTransitiveImports moduleRoots
 
-  let baseConfig ← getSimpleBaseContext buildDir (Hierarchy.fromArray targetModules)
+  let baseConfig ← getSimpleBaseContext buildDir (Hierarchy.fromArray targetModulesAll)
+
+  -- Interproject linking: when `localModuleRoots` is configured (via `DOCGEN_LOCAL_MODULE_ROOTS`),
+  -- only generate pages for the project's own modules. The excluded (external, e.g. Mathlib)
+  -- modules stay in the linking context so references to them still resolve, but their links
+  -- point at the dependency documentation site instead of local pages (see `moduleIsExternal`).
+  let targetModules :=
+    if baseConfig.localModuleRoots.isEmpty then targetModulesAll
+    else targetModulesAll.filter (fun m => baseConfig.localModuleRoots.contains m.getRoot)
+
   -- Add `references` pseudo-module to hierarchy only when bibliography data exists
   let hierarchy := Hierarchy.fromArray
     (if baseConfig.refs.isEmpty then targetModules else targetModules.push `references)

--- a/Main.lean
+++ b/Main.lean
@@ -101,6 +101,19 @@ def runFromDbCmd (p : Parsed) : IO UInt32 := do
   -- only generate pages for the project's own modules. The excluded (external, e.g. Mathlib)
   -- modules stay in the linking context so references to them still resolve, but their links
   -- point at the dependency documentation site instead of local pages (see `moduleIsExternal`).
+  let missingDocsRoots := targetModulesAll.foldl (init := #[]) fun roots mod =>
+    let root := mod.getRoot
+    if !baseConfig.localModuleRoots.isEmpty &&
+        !baseConfig.localModuleRoots.contains root &&
+        (baseConfig.depsDocsUrlFor? mod).isNone &&
+        !roots.contains root then
+      roots.push root
+    else
+      roots
+  if !missingDocsRoots.isEmpty then
+    let roots := ", ".intercalate <| missingDocsRoots.toList.map Name.toString
+    throw <| IO.userError s!"No dependency documentation URL configured for external module roots: {roots}. Set DOCGEN_DEPS_DOCS_URLS or DOCGEN_DEPS_DOCS_URL."
+
   let targetModules :=
     if baseConfig.localModuleRoots.isEmpty then targetModulesAll
     else targetModulesAll.filter (fun m => baseConfig.localModuleRoots.contains m.getRoot)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ The different options are:
 ## Disabling equations
 Generation of equations for definitions is enabled by default, but can be disabled by setting the `DISABLE_EQUATIONS` environment variable to `1`.
 
+## Documenting a project without its dependencies (interproject linking)
+By default `doc-gen4` documents a library together with its whole import closure, so a project
+built on top of a large dependency such as [mathlib4](https://github.com/leanprover-community/mathlib4)
+generates the dependency's documentation too (often several GB). If the dependency already
+publishes its own documentation, you can instead generate pages for *only your own* modules and
+link every reference to the dependency out to its hosted docs, by setting two environment variables:
+
+ * `DOCGEN_LOCAL_MODULE_ROOTS` — a comma-separated list of the top-level module namespaces that
+   belong to your project, e.g. `MyProject` (or `MyProject,MyProjectTest`). Modules whose root is
+   not in this list are treated as *external*: their pages are not generated.
+ * `DOCGEN_DEPS_DOCS_URL` — the base URL of the dependency's documentation site, e.g.
+   `https://leanprover-community.github.io/mathlib4_docs`.
+
+With both set, references to a declaration in an external module link into that site's `/find`
+resolver (`…/find/?pattern=<declaration>#doc`), which looks the declaration up by name and is
+therefore robust to the dependency's documentation being built from a slightly different revision
+than the one you are linking against; module-level links point directly at the corresponding page.
+When `DOCGEN_LOCAL_MODULE_ROOTS` is unset the behaviour is unchanged, i.e. the full import closure
+is documented.
+
 ## How does `docs#Nat.add` from the Lean Zulip work?
 If someone sends a message that contains `docs#Nat.add` on the Lean Zulip this will
 automatically link to `Nat.add` from the `mathlib4` documentation. The way that this

--- a/README.md
+++ b/README.md
@@ -96,18 +96,27 @@ By default `doc-gen4` documents a library together with its whole import closure
 built on top of a large dependency such as [mathlib4](https://github.com/leanprover-community/mathlib4)
 generates the dependency's documentation too (often several GB). If the dependency already
 publishes its own documentation, you can instead generate pages for *only your own* modules and
-link every reference to the dependency out to its hosted docs, by setting two environment variables:
+link every reference to the dependency out to its hosted docs, by setting these environment variables:
 
  * `DOCGEN_LOCAL_MODULE_ROOTS` — a comma-separated list of the top-level module namespaces that
    belong to your project, e.g. `MyProject` (or `MyProject,MyProjectTest`). Modules whose root is
    not in this list are treated as *external*: their pages are not generated.
  * `DOCGEN_DEPS_DOCS_URL` — the base URL of the dependency's documentation site, e.g.
-   `https://leanprover-community.github.io/mathlib4_docs`.
+   `https://leanprover-community.github.io/mathlib4_docs`. This is the fallback URL for every
+   external module root.
+ * `DOCGEN_DEPS_DOCS_URLS` — optional comma-separated per-root overrides of the form
+   `Root=URL`, e.g. `Mathlib=https://.../mathlib4_docs,Batteries=https://.../batteries_docs`.
+   This lets each dependency link to its own documentation site; list multiple roots separately
+   when one dependency owns multiple top-level module namespaces.
 
-With both set, references to a declaration in an external module link into that site's `/find`
-resolver (`…/find/?pattern=<declaration>#doc`), which looks the declaration up by name and is
-therefore robust to the dependency's documentation being built from a slightly different revision
-than the one you are linking against; module-level links point directly at the corresponding page.
+With the local roots and either a fallback URL or per-root URLs set, references to a declaration in
+an external module link into the corresponding site's `/find` resolver
+(`…/find/?pattern=<declaration>#doc`), which looks the declaration up by name and is therefore robust
+to the dependency's documentation being built from a slightly different revision than the one you
+are linking against; module-level links point directly at the corresponding page. Per-root entries
+take precedence over the fallback. Every external module root must have either a per-root entry or a
+fallback URL; doc-gen4 reports an error instead of producing broken links when the configuration is
+incomplete.
 When `DOCGEN_LOCAL_MODULE_ROOTS` is unset the behaviour is unchanged, i.e. the full import closure
 is documented.
 

--- a/test/test-multi-lib-docs.sh
+++ b/test/test-multi-lib-docs.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
-# Regression test: verify that building docs for multiple libraries in one
-# `lake build` produces HTML for all of them, and that an incremental build
-# of a third library doesn't remove the first two.
+# Regression tests for multi-library and interproject documentation generation:
+# - concurrent and incremental builds retain every generated library;
+# - local-only builds omit dependency pages and link each dependency to its own docs site;
+# - incomplete external documentation mappings fail instead of producing broken links.
 #
 # Usage: run from the doc-gen4 repo root (or pass it as $1).
 #   ./test/test-multi-lib-docs.sh
@@ -34,6 +35,9 @@ require «doc-gen4» from "$DOCGEN4_DIR"
 lean_lib LibA
 lean_lib LibB
 lean_lib LibC
+lean_lib DepA
+lean_lib DepB
+lean_lib Project
 EOF
 
 cat > "$TEST_DIR/LibA.lean" << 'EOF'
@@ -49,6 +53,27 @@ EOF
 cat > "$TEST_DIR/LibC.lean" << 'EOF'
 /-- A greeting from LibC -/
 def libCGreeting := "hello from C"
+EOF
+
+cat > "$TEST_DIR/DepA.lean" << 'EOF'
+/-- A greeting from the first dependency -/
+def depAGreeting := "hello from dependency A"
+EOF
+
+cat > "$TEST_DIR/DepB.lean" << 'EOF'
+/-- A greeting from the second dependency -/
+def depBGreeting := "hello from dependency B"
+EOF
+
+cat > "$TEST_DIR/Project.lean" << 'EOF'
+import DepA
+import DepB
+
+/-- A declaration whose type refers to both dependencies. -/
+theorem projectUsesDeps : depAGreeting = depAGreeting ∧ depBGreeting = depBGreeting := ⟨rfl, rfl⟩
+
+/-- A declaration whose type uses the fallback documentation site. -/
+def projectString : String := "project"
 EOF
 
 export LEAN_ABORT_ON_PANIC=1
@@ -72,6 +97,29 @@ check_html() {
   fi
 }
 
+check_no_html() {
+  local doc_dir="$1"
+  shift
+  for mod in "$@"; do
+    if [ -f "$doc_dir/$mod.html" ]; then
+      echo "FAIL: $mod.html should not have been generated"
+      exit 1
+    else
+      echo "OK: $mod.html was not generated"
+    fi
+  done
+}
+
+check_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "FAIL: $file does not contain: $expected"
+    exit 1
+  fi
+  echo "OK: $file contains: $expected"
+}
+
 # --- Phase 1: build LibA and LibB concurrently ---
 
 echo "=== Building LibA:docs and LibB:docs ==="
@@ -84,4 +132,53 @@ echo "=== Building LibC:docs incrementally ==="
 (cd "$TEST_DIR" && lake build LibC:docs)
 check_html LibA LibB LibC
 
-echo "SUCCESS: All three libraries have HTML documentation"
+# --- Phase 3: generate only local project docs with per-dependency URLs ---
+
+echo "=== Building Project doc info ==="
+(cd "$TEST_DIR" && lake build Project:docInfo)
+
+INTERPROJECT_BUILD="$TEST_DIR/interproject-build"
+INTERPROJECT_DOC_DIR="$INTERPROJECT_BUILD/doc"
+DOCGEN4_BIN="$DOCGEN4_DIR/.lake/build/bin/doc-gen4"
+
+echo "=== Generating local-only docs with per-dependency URLs ==="
+env \
+  DOCGEN_LOCAL_MODULE_ROOTS=Project \
+  DOCGEN_DEPS_DOCS_URL=https://deps.example/fallback/ \
+  DOCGEN_DEPS_DOCS_URLS='DepA=https://deps.example/a/,DepB=https://deps.example/b' \
+  "$DOCGEN4_BIN" fromDb \
+    --build "$INTERPROJECT_BUILD" \
+    --manifest "$INTERPROJECT_BUILD/manifest.json" \
+    "$TEST_DIR/.lake/build/api-docs.db" Project
+
+check_html_file="$INTERPROJECT_DOC_DIR/Project.html"
+if [ ! -f "$check_html_file" ]; then
+  echo "FAIL: Project.html was not generated"
+  exit 1
+fi
+echo "OK: Project.html exists"
+check_no_html "$INTERPROJECT_DOC_DIR" DepA DepB Init
+check_contains "$check_html_file" 'https://deps.example/a/find/?pattern=depAGreeting#doc'
+check_contains "$check_html_file" 'https://deps.example/b/find/?pattern=depBGreeting#doc'
+check_contains "$check_html_file" 'https://deps.example/a/DepA.html'
+check_contains "$check_html_file" 'https://deps.example/b/DepB.html'
+check_contains "$check_html_file" 'https://deps.example/fallback/find/?pattern=String#doc'
+
+# --- Phase 4: reject incomplete URL mappings ---
+
+echo "=== Checking incomplete dependency URL configuration ==="
+INCOMPLETE_BUILD="$TEST_DIR/incomplete-build"
+INCOMPLETE_LOG="$TEST_DIR/incomplete.log"
+if env \
+    -u DOCGEN_DEPS_DOCS_URL \
+    DOCGEN_LOCAL_MODULE_ROOTS=Project \
+    DOCGEN_DEPS_DOCS_URLS='DepA=https://deps.example/a,DepB=https://deps.example/b' \
+    "$DOCGEN4_BIN" fromDb \
+      --build "$INCOMPLETE_BUILD" \
+      "$TEST_DIR/.lake/build/api-docs.db" Project >"$INCOMPLETE_LOG" 2>&1; then
+  echo "FAIL: incomplete dependency URL configuration unexpectedly succeeded"
+  exit 1
+fi
+check_contains "$INCOMPLETE_LOG" 'No dependency documentation URL configured for external module roots:'
+
+echo "SUCCESS: Multi-library and interproject documentation tests passed"


### PR DESCRIPTION
By default `doc-gen4` documents a library together with its entire import closure, so a project built on top of a large dependency such as Mathlib regenerates the dependency's documentation too — often several GB, and close to the GitHub Pages ~1 GB artifact limit. This PR adds an opt-in mode that generates pages for **only the project's own modules** and links references to its dependencies out to their already-published documentation.

Three environment variables control it (in the spirit of the existing `DOCGEN_SRC`):

- `DOCGEN_LOCAL_MODULE_ROOTS` — a comma-separated list of the top-level module namespaces that belong to your project (e.g. `MyProject`). A module whose root is not listed is treated as *external*, and its pages are not generated.
- `DOCGEN_DEPS_DOCS_URL` — an optional fallback base URL for external dependency documentation, e.g. `https://leanprover-community.github.io/mathlib4_docs`.
- `DOCGEN_DEPS_DOCS_URLS` — optional comma-separated per-root overrides of the form `Root=URL`, e.g. `Mathlib=https://.../mathlib4_docs,Batteries=https://.../batteries_docs`. List multiple roots separately when one dependency owns multiple top-level namespaces.

For each external module, a per-root entry takes precedence over the fallback URL. A reference to an external declaration links to the selected site's `/find` resolver (`…/find/?pattern=<decl>#doc`), which looks the declaration up by name and so tolerates the dependency's docs being built from a slightly different revision than the one being linked against; module-level links point directly at the corresponding page. Every external module root must have either a per-root entry or a fallback, and `doc-gen4` reports a configuration error rather than producing broken local links when a mapping is missing.

The excluded modules stay in the linking context so cross-references still resolve. When `DOCGEN_LOCAL_MODULE_ROOTS` is unset, the behaviour is unchanged.

The change is localized to the two link builders (`moduleNameToLink` / `declNameToLink`), dependency-URL selection and validation, and a render-set filter in `fromDb`, with the configuration read in `getSimpleBaseContext`. The README documents the variables. The multi-library regression test now also covers distinct dependency sites, fallback links, trailing-slash normalization, omitted dependency pages, and incomplete-configuration errors.

Validated end-to-end against [Tau Ceti](https://github.com/TauCetiProject/TauCeti), a ~580-module Mathlib-downstream library: with `DOCGEN_LOCAL_MODULE_ROOTS=TauCeti`, only the 581 TauCeti pages are generated (no `Mathlib`/`Init`/`Std`/… trees), references to Mathlib declarations link to `mathlib4_docs`, and there are no broken local links — cutting the output from ~963 MB to tens of MB.
