### PR TITLE
chore: bump toolchain to v4.32.1

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.0
+leanprover/lean4:v4.32.1


### PR DESCRIPTION
Just to run CI, this PR should not be merged.