### PR TITLE
fix: preserve paragraphs in recommended spelling descriptions

### DIFF
--- a/DocGen4/Process/NameInfo.lean
+++ b/DocGen4/Process/NameInfo.lean
@@ -44,10 +44,27 @@ where
       .code spelling.recommendedSpelling
     ]
     let additionalInfoLines := spelling.additionalInformation?.map (·.split '\n' |>.toStringList)
-    .mk <| (#[.para ·]) <| match additionalInfoLines with
-    | none | some [] => firstLine ++ #[.text ".", .linebreak "\n", .linebreak "\n"]
-    | some [l] => firstLine ++ #[.text s!" ({l.trimAsciiEnd}).", .linebreak "\n", .linebreak "\n"]
-    | some ls => firstLine ++ #[.text ".", .linebreak "\n", .linebreak "\n", .text (String.join ls), .linebreak "\n", .linebreak "\n"]
+    match additionalInfoLines with
+    | none | some [] =>
+      .mk #[.para (firstLine ++ #[.text ".", .linebreak "\n", .linebreak "\n"])]
+    | some [l] =>
+      .mk #[.para (firstLine ++ #[.text s!" ({l.trimAsciiEnd}).", .linebreak "\n", .linebreak "\n"])]
+    | some ls =>
+      .mk <| #[.para (firstLine ++ #[.text "."])] ++ additionalInfoBlocks ls
+  additionalInfoBlocks (lines : List String) : Array (Doc.Block ElabInline ElabBlock) := Id.run do
+    let mut blocks := #[]
+    let mut paragraph := #[]
+    for line in lines do
+      let line := line.trimAscii.copy
+      if line.isEmpty then
+        if !paragraph.isEmpty then
+          blocks := blocks.push (.para #[.text (String.intercalate " " paragraph.toList)])
+          paragraph := #[]
+      else
+        paragraph := paragraph.push line
+    if !paragraph.isEmpty then
+      blocks := blocks.push (.para #[.text (String.intercalate " " paragraph.toList)])
+    return blocks
 
 
 open Lean.Parser.Tactic.Doc in


### PR DESCRIPTION
Fixes #398.

## Summary

Preserve spaces and paragraph boundaries when rendering multiline `recommended_spelling` descriptions as Verso content.

Consecutive non-empty source lines are joined with spaces, while blank lines produce separate paragraphs. Existing behavior for absent and single-line descriptions remains unchanged.

## Root cause

The additional information was split into lines and combined using `String.join`, which inserts no separator. This concatenated adjacent words and discarded paragraph boundaries.

Lean's string representation preserves line breaks and blank lines when generating Markdown. This change mirrors the resulting soft-wrap and paragraph structure using Verso blocks.

## Verification

Rendered the reproduction from the linked issue using both the baseline and patched versions of doc-gen4. The Lean input was identical in both builds.

### Before

```html
<p>First paragraph spansmultiple source lines.Second paragraph.</p>
```

<img width="3117" height="802" alt="image" src="https://github.com/user-attachments/assets/b244730f-9261-417c-910f-5cbd3ec2537f" />

### After

```html
<p>First paragraph spans multiple source lines.</p>
<p>Second paragraph.</p>
```

<img width="3117" height="802" alt="image" src="https://github.com/user-attachments/assets/d526d6d3-d9a8-4806-9cee-7333f98d416b" />

Both documentation builds completed successfully with Lean `v4.33.0-rc1`, and the generated pages were served locally over HTTP and verified in Chromium.