### PR TITLE
fix: preserve spaces/paragraphs in recommended_spelling docs

### DIFF
--- a/DocGen4/Process/NameInfo.lean
+++ b/DocGen4/Process/NameInfo.lean
@@ -47,7 +47,25 @@ where
     .mk <| (#[.para ·]) <| match additionalInfoLines with
     | none | some [] => firstLine ++ #[.text ".", .linebreak "\n", .linebreak "\n"]
     | some [l] => firstLine ++ #[.text s!" ({l.trimAsciiEnd}).", .linebreak "\n", .linebreak "\n"]
-    | some ls => firstLine ++ #[.text ".", .linebreak "\n", .linebreak "\n", .text (String.join ls), .linebreak "\n", .linebreak "\n"]
+    | some ls => firstLine ++ #[.text ".", .linebreak "\n", .linebreak "\n", .text (joinAdditionalInfo ls),
+        .linebreak "\n", .linebreak "\n"]
+  /--
+  Join wrapped `recommended_spelling` description lines with spaces, while blank lines
+  remain paragraph boundaries.
+  -/
+  joinAdditionalInfo (ls : List String) : String := Id.run do
+    let mut paras : Array String := #[]
+    let mut cur : Array String := #[]
+    for l in ls do
+      if l.isEmpty then
+        if cur.size ≠ 0 then
+          paras := paras.push (" ".intercalate cur.toList)
+          cur := #[]
+      else
+        cur := cur.push l.trimAsciiEnd
+    if cur.size ≠ 0 then
+      paras := paras.push (" ".intercalate cur.toList)
+    "\n\n".intercalate paras.toList
 
 
 open Lean.Parser.Tactic.Doc in


### PR DESCRIPTION
## Summary
- Multiline `recommended_spelling` additional info was concatenated with `String.join`, dropping spaces between wrapped lines and paragraph breaks.
- Join wrapped lines with spaces and keep blank lines as `\n\n` paragraph boundaries.

Fixes #398.

## Test plan
- [ ] Rebuild docs for a decl with a multiline `recommended_spelling` description and confirm spacing/paragraphs match the issue expectation

Made with [Cursor](https://cursor.com)