### PR TITLE
feat: let libraries attach rendered docs to a declaration

### DIFF
--- a/DocGen4/Process.lean
+++ b/DocGen4/Process.lean
@@ -9,6 +9,7 @@ import DocGen4.Process.Attributes
 import DocGen4.Process.AxiomInfo
 import DocGen4.Process.Base
 import DocGen4.Process.ClassInfo
+import DocGen4.Process.DeclMath
 import DocGen4.Process.DefinitionInfo
 import DocGen4.Process.DocInfo
 import DocGen4.Process.Hierarchy

--- a/DocGen4/Process/DeclMath.lean
+++ b/DocGen4/Process/DeclMath.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nicolas Rouquette
+-/
+import Lean
+
+/-!
+# Per-declaration extra documentation (`declMathExt`)
+
+A generic extension point: any downstream library can attach an extra block of rendered documentation
+to a declaration via `addDeclMath` (typically a block of Markdown containing LaTeX, e.g.
+`$$\sigma^0 = a\,\mathrm{NDVI} + \ldots$$`). doc-gen4 appends it to the declaration's docstring in
+`DocGen4.Process.getDocString?`, so it flows through the normal, MathJax-processed docstring rendering
+path — no special-casing anywhere in the renderer.
+
+This lets a library surface human-friendly notation for a declaration (a math formula, a diagram, a
+prose note computed from metadata) without doc-gen4 knowing anything about the library. The data rides
+in the environment (serialized into the `.olean`), so it is available to the separate doc-gen4 process
+that loads the target project. This mirrors how doc-gen4 already augments docstrings with
+`getRecommendedSpellingText` / `getTacticExtensionText`.
+-/
+
+namespace DocGen4.Process
+
+open Lean
+
+/--
+Environment extension mapping a declaration name to extra rendered documentation. The value is
+Markdown and may contain `$…$` / `$$…$$`, which the docstring renderer passes through to MathJax.
+-/
+initialize declMathExt : SimplePersistentEnvExtension (Name × String) (NameMap String) ←
+  registerSimplePersistentEnvExtension {
+    addEntryFn := fun m (n, s) => m.insert n s
+    addImportedFn := fun ass =>
+      ass.foldl (fun m as => as.foldl (fun m (n, s) => m.insert n s) m) ({} : NameMap String)
+  }
+
+/--
+Attach extra rendered documentation `markdown` to declaration `declName`. Downstream libraries call
+this (e.g. from an attribute) so doc-gen4 renders `markdown` inside the declaration's docstring.
+-/
+def addDeclMath [Monad m] [MonadEnv m] (declName : Name) (markdown : String) : m Unit :=
+  modifyEnv fun env => declMathExt.addEntry env (declName, markdown)
+
+/-- The extra rendered documentation attached to `declName`, if any. -/
+def getDeclMath? (env : Environment) (declName : Name) : Option String :=
+  (declMathExt.getState env).get? declName
+
+end DocGen4.Process

--- a/DocGen4/Process/NameInfo.lean
+++ b/DocGen4/Process/NameInfo.lean
@@ -7,6 +7,7 @@ import Lean
 
 import DocGen4.Process.Base
 import DocGen4.Process.Attributes
+import DocGen4.Process.DeclMath
 import DocGen4.RenderedCode
 
 namespace DocGen4.Process
@@ -71,15 +72,26 @@ open Lean.Parser.Tactic.Doc in
 open Lean.Parser.Term.Doc in
 def getDocString? (env : Environment) (name : Name) : IO (Option (String ⊕ (VersoDocString × String))) := do
   let name := alternativeOfTactic env name |>.getD name
+  -- Extra rendered documentation attached by a downstream library (see `DocGen4.Process.DeclMath`),
+  -- appended to the docstring's Markdown so it flows through the normal, MathJax-processed docstring
+  -- rendering path (`Output.docStringToHtml` consumes exactly this Markdown for both cases below).
+  let math? := getDeclMath? env name
+  let appendMath (md : String) : String :=
+    match math? with
+    | some m => md ++ "\n\n" ++ m
+    | none   => md
   match (← findInternalDocString? env name) with
-  | none => return none
+  | none => return math?.map .inl
   | some (.inr verso) =>
     let exts := getTacticExtensionText env name |>.map (#[·]) |>.getD #[]
     let spellings := getRecommendedSpellingText env name |>.map (#[·]) |>.getD #[]
     let verso := { verso with text := verso.text ++ exts ++ spellings }
-    return some <| .inr (verso, ← versoDocToMarkdown env verso)
+    return some <| .inr (verso, appendMath (← versoDocToMarkdown env verso))
   | some (.inl _) =>
-    return (·.map .inl) (← Lean.findDocString? env name)
+    match (← Lean.findDocString? env name), math? with
+    | some doc, _      => return some (.inl (appendMath doc))
+    | none,     some m => return some (.inl m)
+    | none,     none   => return none
 
 
 def NameInfo.ofTypedName (n : Name) (t : Expr) : MetaM NameInfo := do


### PR DESCRIPTION
## What

Adds a small, generic extension point that lets a downstream library attach an extra block of
already-rendered documentation to any declaration, which doc-gen4 then renders on that
declaration's page — without doc-gen4 knowing anything about the library.

- **`DocGen4/Process/DeclMath.lean`** (new, ~50 lines): an environment extension `declMathExt` with
  - `addDeclMath declName markdown` — for producers (e.g. called from an attribute), and
  - `getDeclMath? env declName` — the reader.

  The data rides in the environment, so it is serialized into the `.olean` and is therefore
  available to the separate doc-gen4 process that loads the target project.

- **`getDocString?`** (`Process/NameInfo.lean`): appends the attached Markdown to the declaration's
  docstring Markdown, so it flows through the normal, MathJax-processed docstring path
  (`Output.docStringToHtml`). No renderer special-casing and no schema change. This mirrors how
  doc-gen4 already augments docstrings via `getRecommendedSpellingText` / `getTacticExtensionText`.

Both docstring shapes are handled (`.inl` Markdown and `.inr` Verso — the attached Markdown is
appended to the Markdown rendition that `docStringToHtml` consumes for both), and a declaration with
attached docs but no docstring of its own renders the attached Markdown alone.

## Why

Libraries increasingly compute a human-friendly presentation of a declaration from its metadata — a
LaTeX formula for a numeric model, a generated diagram, a prose note — and want it on the doc page.
Today that means either abusing the docstring or patching doc-gen4. This gives them a clean, general
hook (attach Markdown; doc-gen4 renders it) with no coupling.

Example use: an attribute that renders a definition's value as a `$$…$$` LaTeX equation and calls
`addDeclMath`, so the doc page shows the typeset math.

## Notes

- The diff is **1 new file + 2 tiny edits** (an import in the `Process` aggregator, and the
  `getDocString?` append).
- Builds green on `main` (v4.33.0-rc2): `lake build DocGen4` — 131 jobs.
- Verified end-to-end from a downstream library: an attribute writes via `addDeclMath`, the entry
  survives into the `.olean`, and a separate process reads it back via `getDeclMath?` and renders
  the `$$…$$` block through MathJax.
